### PR TITLE
Fixes few minor issues in AMDA module

### DIFF
--- a/speasy/amda/amda.py
+++ b/speasy/amda/amda.py
@@ -95,6 +95,11 @@ class AMDA:
         self.catalog = {}
         if "AMDA/inventory" in _cache:
             self._unpack_inventory(_cache["AMDA/inventory"])
+            if any(map(lambda d: d == {},
+                       [self.parameter, self.mission, self.observatory, self.instrument, self.dataset,
+                        self.datasetGroup, self.component, self.dataCenter, self.folder, self.timeTable,
+                        self.catalog])):
+                self.update_inventory()
         else:
             self.update_inventory()
 

--- a/tests/test_amda_parameter.py
+++ b/tests/test_amda_parameter.py
@@ -5,7 +5,7 @@
 
 import unittest
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta
 from speasy.amda import AMDA, load_csv
 from speasy.common.variable import SpeasyVariable
 from ddt import ddt, data
@@ -43,8 +43,11 @@ class SimpleRequest(unittest.TestCase):
         self.assertTrue(self.data.time.dtype == float)
 
     def test_time_range(self):
-        self.assertTrue(datetime.utcfromtimestamp(self.data.time[0]) == self.start)
-        self.assertTrue(datetime.utcfromtimestamp(self.data.time[-1]) == self.stop)
+        min_dt = min(self.data.time[1:] - self.data.time[:-1])
+        self.assertTrue(
+            self.start <= datetime.utcfromtimestamp(self.data.time[0]) < self.start + timedelta(seconds=min_dt))
+        self.assertTrue(
+            self.stop > datetime.utcfromtimestamp(self.data.time[-1]) >= self.stop - timedelta(seconds=min_dt))
 
     def test_dataset_not_none(self):
         self.assertIsNotNone(self.dataset)


### PR DESCRIPTION
- Since we added new inventory entries there could be some code path where inventory was cached but with missing entries.
- Given a time range a downloaded parameter won't match exactly start time and end time but should contain the first data at or after start time to the last data before stop time.
