### PR TITLE
[RTD] Adds numpydoc in requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx-rtd-theme
 argh
+numpydoc


### PR DESCRIPTION
RTD builds fail at least because numpydoc was missing.