### PR TITLE
[CI] Check that each push or PR doesn't break release process

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -40,6 +40,12 @@ jobs:
         pip install -r docs/requirements.txt
         pytest --cov=./ --cov-report=xml
         make doctest
+    - name: Check that release process is not broken
+      if: matrix.python-version == '3.7'
+      run: |
+        pip install setuptools wheel twine
+        python setup.py sdist bdist_wheel
+        twine check dist/*
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.8'
       uses: codecov/codecov-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,12 @@ jobs:
         pip install -r docs/requirements.txt
         pytest --cov=./ --cov-report=xml
         make doctest
+    - name: Check that release process is not broken
+      if: matrix.python-version == '3.7'
+      run: |
+        pip install setuptools wheel twine
+        python setup.py sdist bdist_wheel
+        twine check dist/*
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.8'
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
While releasing 0.10.0, I discovered that I broke title consistency between README and HISTORY which are used for generating PyPi landing page.
To avoid this, I propose to generate python packages on each push and PR and just run `twine check` to ensure everything still works.