### PR TITLE
Adds TimeTable and Catalog conversion to Pandas DataFrames

### DIFF
--- a/speasy/products/catalog.py
+++ b/speasy/products/catalog.py
@@ -5,6 +5,7 @@ from speasy.core.datetime_range import DateTimeRange
 from datetime import datetime
 from typing import List
 from speasy.core import all_of_type, listify
+import pandas as pds
 
 
 def _all_are_events(event_list):
@@ -91,10 +92,10 @@ class Catalog:
         if events:
             self.append(events)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index) -> Event:
         return self._events[index]
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._events)
 
     def append(self, events: Event or List[Event]) -> None:
@@ -143,5 +144,17 @@ class Catalog:
         """
         return self._events.pop(index)
 
-    def __repr__(self):
+    def to_dataframe(self) -> pds.DataFrame:
+        columns = set()
+        data = []
+        for e in self:
+            columns.update(e.meta.keys())
+        columns = list(columns)
+        for e in self:
+            row = [e.start_time, e.stop_time] + [e.meta.get(column, None) for column in columns]
+            data.append(row)
+        columns = ['start_time', 'stop_time'] + columns
+        return pds.DataFrame(columns=columns, data=data)
+
+    def __repr__(self) -> str:
         return f"""<Catalog: {self.name}>"""

--- a/speasy/products/timetable.py
+++ b/speasy/products/timetable.py
@@ -1,6 +1,7 @@
 from speasy.core.datetime_range import DateTimeRange
 from typing import List
 from speasy.core import all_of_type, listify
+import pandas as pds
 
 
 def _all_are_datetime_ranges(dt_list):
@@ -39,6 +40,9 @@ class TimeTable:
 
     def pop(self, index=-1):
         return self._storage.pop(index)
+
+    def to_dataframe(self) -> pds.DataFrame:
+        return pds.DataFrame(columns=['start_time', 'stop_time'], data=[(*r,) for r in self])
 
     def __repr__(self):
         return f"""<TimeTable: {self.name}>"""

--- a/speasy/webservices/amda/ws.py
+++ b/speasy/webservices/amda/ws.py
@@ -386,8 +386,8 @@ class AMDA_Webservice:
         --------
 
         >>> import speasy as spz
-        >>> spz.amda.get_catalog("sharedcatalog_0")
-        <Catalog: choc_MPB_catalogue_MEX>
+        >>> spz.amda.get_catalog("sharedcatalog_22")
+        <Catalog: model_regions_plasmas_mms_2019>
 
         """
         return self._impl.dl_catalog(to_xmlid(catalog_id), **kwargs)

--- a/tests/test_amda_catalog.py
+++ b/tests/test_amda_catalog.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `amda` package timetable implementation."""
+
+import unittest
+import speasy as spz
+from speasy.core.datetime_range import DateTimeRange
+
+
+class CatalogRequests(unittest.TestCase):
+    def setUp(self):
+        self.cat = spz.amda.get_catalog("sharedcatalog_33")
+
+    def tearDown(self):
+        pass
+
+    def test_catalog_shape(self):
+        self.assertTrue(len(self.cat) > 0)
+
+    def test_catalog_has_a_name(self):
+        self.assertIsNot(self.cat.name, "listOfICMEs_Nguyen")
+
+    def test_is_convertible_to_dataframe(self):
+        df = self.cat.to_dataframe()
+        self.assertTrue(len(df) > 0)
+        self.assertListEqual(list(df.columns), ['start_time', 'stop_time', 'col3'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_amda_timetable.py
+++ b/tests/test_amda_timetable.py
@@ -5,6 +5,7 @@
 
 import unittest
 import speasy as spz
+from speasy.core.datetime_range import DateTimeRange
 
 
 class TimetableRequests(unittest.TestCase):
@@ -19,6 +20,13 @@ class TimetableRequests(unittest.TestCase):
 
     def test_timetable_has_a_name(self):
         self.assertIsNot(self.tt.name, "")
+
+    def test_is_convertible_to_dataframe(self):
+        df = self.tt.to_dataframe()
+        self.assertTrue(len(df) > 0)
+        self.assertListEqual(list(df.columns), ['start_time', 'stop_time'])
+        df_ranges = list(map(lambda row: DateTimeRange(*row), df.values))
+        self.assertListEqual(df_ranges, list(self.tt))
 
 
 if __name__ == '__main__':

--- a/tests/test_spwc.py
+++ b/tests/test_spwc.py
@@ -67,7 +67,7 @@ class GetSpwc(unittest.TestCase):
             "disable_proxy": True
         },
         {
-            "product": spz.inventory.data_tree.amda.Catalogs.SharedCatalogs.MARS.choc_MPB_catalogue_MEX
+            "product": spz.inventory.data_tree.amda.Catalogs.SharedCatalogs.MARS.MEXShockCrossings
         },
         {
             "product": spz.inventory.data_tree.amda.TimeTables.SharedTimeTables.EARTH.Event_list_tail_hall_reconnection_SC1


### PR DESCRIPTION
This does a simple conversion to Pandas DataFrames for TT and Catalogs. Note that Catalogs as defined in Speasy doesn't force Events to always have the same meta-data, this leads to a DataFrame where columns are the union of all Events meta-data plus as usual start_time and stop_time.



Closes #35
