### PR TITLE
Cda support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ python_dateutil
 typing
 python-dateutil
 astropy
+pyistp

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ ddt
 spwc
 pytest
 pytest-cov
+pyistp

--- a/speasy/__init__.py
+++ b/speasy/__init__.py
@@ -24,6 +24,7 @@ ssc = webservices.SSC_Webservice()
 __PROVIDERS__ = {
     'amda': amda.get_data,
     'cdaweb': cda.get_data,
+    'cda': cda.get_data,
     'sscweb': ssc.get_trajectory
 }
 
@@ -80,10 +81,11 @@ def get_data(product: str or SpeasyIndex, start_time=None, stop_time=None, **kwa
             return __PROVIDERS__[provider]('/'.join(components[1:]), start_time=start_time, stop_time=stop_time,
                                            **kwargs)
     raise ValueError(
-        f'{components[0]} not found in data provider list\nSupported providers are:\n{list(__PROVIDERS__.keys())}')
+        f"Can't find a provider for {product}")
 
 
-def get_orbit(body: str, start_time, stop_time, coordinate_system: str = 'gse', **kwargs) -> SpeasyVariable:
+def get_orbit(body: str or SpeasyIndex, start_time, stop_time, coordinate_system: str = 'gse',
+              **kwargs) -> SpeasyVariable:
     return ssc.get_trajectory(body, start_time, stop_time, coordinate_system=coordinate_system, **kwargs)
 
 

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -137,6 +137,9 @@ cache_size = ConfigEntry("CACHE", "size", "20e9", description="""Sets the maximu
 cache_path = ConfigEntry("CACHE", "path", str(appdirs.user_cache_dir("speasy", "LPP")),
                          description="""Sets Speasy cache path.""")
 
+index_path = ConfigEntry("INDEX", "path", f'{appdirs.user_data_dir("speasy", "LPP")}/index')
+cdaweb_inventory_data_path = ConfigEntry("INDEX", "path", f'{appdirs.user_data_dir("speasy", "LPP")}/cda_inventory')
+
 amda_username = ConfigEntry("AMDA", "username",
                             description="""Your AMDA username, once set, you will be able to get your private products.""")
 amda_password = ConfigEntry("AMDA", "password",

--- a/speasy/core/__init__.py
+++ b/speasy/core/__init__.py
@@ -179,3 +179,49 @@ class AllowedKwargs(object):
                 f"Unexpected keyword argument {unexpected_args}, allowed keyword arguments are {self.allowed_list}")
 
         return wrapped
+
+
+def fix_name(name: str):
+    """Makes given input compatible with python charset https://docs.python.org/3/reference/lexical_analysis.html#identifiers
+
+    Parameters
+    ----------
+    name: str
+        input string to sanitize
+
+    Returns
+    -------
+    str
+        a string compatible with python naming rules
+
+
+    Examples
+    --------
+    >>> fix_name('Parker Solar Probe (PSP)')
+    'ParkerSolarProbePSP'
+
+    >>> fix_name('IS⊙ISEPI_Lo')
+    'ISoISEPI_Lo'
+
+    >>> fix_name('all_Legal_strings_123')
+    'all_Legal_strings_123'
+
+    """
+    rules = (
+        ('-', '_'),
+        (':', ''),
+        ('.', '_'),
+        ('(', ''),
+        (')', ''),
+        ('/', ''),
+        (' ', ''),
+        ('{', ''),
+        ('}', ''),
+        ('(', ''),
+        ('⊙', 'o')
+    )
+
+    for bad, replacement in rules:
+        if bad in name:
+            name = name.replace(bad, replacement)
+    return name

--- a/speasy/core/__init__.py
+++ b/speasy/core/__init__.py
@@ -122,7 +122,7 @@ def listify(obj: Any) -> List:
         return [obj]
 
 
-def make_utc_datetime(input_dt: str or datetime or np.float64 or float) -> datetime:
+def make_utc_datetime(input_dt: str or datetime or np.float64 or float or np.datetime64) -> datetime:
     """Makes UTC datetime from given input.
 
     Parameters
@@ -151,6 +151,10 @@ def make_utc_datetime(input_dt: str or datetime or np.float64 or float) -> datet
         return datetime.utcfromtimestamp(input_dt)
     if type(input_dt) is str:
         input_dt = parse(input_dt)
+    if type(input_dt) is np.datetime64:
+        if input_dt.dtype == np.dtype('datetime64[ns]'):
+            return datetime.utcfromtimestamp(input_dt.astype(int) * 1e-9)
+
     return datetime(input_dt.year, input_dt.month, input_dt.day, input_dt.hour, input_dt.minute, input_dt.second,
                     input_dt.microsecond, tzinfo=timezone.utc)
 

--- a/speasy/core/cdf/__init__.py
+++ b/speasy/core/cdf/__init__.py
@@ -1,0 +1,15 @@
+import pyistp
+from ...products import SpeasyVariable
+
+
+def load_variable(variable="", file=None, buffer=None) -> SpeasyVariable or None:
+    istp = pyistp.load(file=file, buffer=buffer)
+    if istp and variable in istp.data_variables():
+        var = istp.data_variable(variable)
+        if len(var.axes) <= 2:
+            if len(var.axes) == 2:
+                y = var.axes[1].values.copy()
+            else:
+                y = None
+            return SpeasyVariable(time=var.axes[0].values.copy(), data=var.values.copy(), meta=var.attributes, y=y,
+                                  columns=var.labels)

--- a/speasy/core/datetime_range.py
+++ b/speasy/core/datetime_range.py
@@ -6,8 +6,8 @@ import numpy as np
 class DateTimeRange:
     __slots__ = ['_rng']
 
-    def __init__(self, start_time: datetime or str or np.float64 or float,
-                 stop_time: datetime or str or np.float64 or float):
+    def __init__(self, start_time: datetime or str or np.float64 or float or np.datetime64,
+                 stop_time: datetime or str or np.float64 or float or np.datetime64):
         self._rng = [make_utc_datetime(start_time), make_utc_datetime(stop_time)]
 
     @property
@@ -15,7 +15,7 @@ class DateTimeRange:
         return self._rng[0]
 
     @start_time.setter
-    def start_time(self, start_time: datetime or str or np.float64 or float):
+    def start_time(self, start_time: datetime or str or np.float64 or float or np.datetime64):
         self._rng[0] = make_utc_datetime(start_time)
 
     @property
@@ -23,7 +23,7 @@ class DateTimeRange:
         return self._rng[1]
 
     @stop_time.setter
-    def stop_time(self, stop_time: datetime or str or np.float64 or float):
+    def stop_time(self, stop_time: datetime or str or np.float64 or float or np.datetime64):
         self._rng[1] = make_utc_datetime(stop_time)
 
     def __eq__(self, other):

--- a/speasy/core/index/__init__.py
+++ b/speasy/core/index/__init__.py
@@ -1,0 +1,5 @@
+from .speasy_index import SpeasyIndex as _SpeasyIndex
+
+index = _SpeasyIndex()
+
+

--- a/speasy/core/index/speasy_index.py
+++ b/speasy/core/index/speasy_index.py
@@ -1,0 +1,14 @@
+from typing import Union
+import diskcache as dc
+from speasy.config import index_path
+
+
+class SpeasyIndex:
+    def __init__(self):
+        self._index = dc.Index(index_path.get())
+
+    def get(self, module, key, default=None):
+        return self._index.get(f'{module}/{key}', default)
+
+    def set(self, module, key, value):
+        self._index[f'{module}/{key}'] = value

--- a/speasy/inventory/__init__.py
+++ b/speasy/inventory/__init__.py
@@ -21,6 +21,7 @@ class ProviderInventory:
 class FlatInventories:
     amda = ProviderInventory()
     ssc = ProviderInventory()
+    cda = ProviderInventory()
 
 
 flat_inventories = FlatInventories()

--- a/speasy/webservices/amda/_impl.py
+++ b/speasy/webservices/amda/_impl.py
@@ -96,7 +96,7 @@ class AmdaImpl:
             var = load_csv(url)
             if len(var):
                 log.debug(
-                    f'Loaded var: data shape = {var.values.shape}, data start time = {datetime.utcfromtimestamp(var.time[0])}, data stop time = {datetime.utcfromtimestamp(var.time[-1])}')
+                    f'Loaded var: data shape = {var.values.shape}, data start time = {var.time[0]}, data stop time = {var.time[-1]}')
             else:
                 log.debug('Loaded var: Empty var')
             return var

--- a/speasy/webservices/amda/inventory.py
+++ b/speasy/webservices/amda/inventory.py
@@ -2,6 +2,7 @@
 """
 from types import SimpleNamespace
 from .indexes import AMDATimetableIndex, AMDAComponentIndex, AMDAParameterIndex, AMDADatasetIndex, AMDACatalogIndex
+from ...core import fix_name
 import xml.etree.ElementTree as Et
 
 
@@ -11,15 +12,10 @@ class AMDAPathIndex(SimpleNamespace):
 
 
 class AmdaXMLParser:
-    @staticmethod
-    def fix_name(name: str):
-        return name.strip().replace('-', '_').replace(':', '').replace('.', '_').replace('(', '').replace(')',
-                                                                                                          '').replace(
-            '/', '').replace(' ', '').replace('⊙','o')
 
     @staticmethod
     def fix_names(**kwargs):
-        return {AmdaXMLParser.fix_name(key): value for key, value in kwargs.items()}
+        return {fix_name(key): value for key, value in kwargs.items()}
 
     @staticmethod
     def fix_xmlid(**kwargs):
@@ -33,7 +29,7 @@ class AmdaXMLParser:
     @staticmethod
     def make_any_node(parent, node, ctor, name_key='xmlid', is_public=True):
         new = ctor(AmdaXMLParser.fix_names(**AmdaXMLParser.fix_xmlid(**node.attrib)), is_public=is_public)
-        name = AmdaXMLParser.fix_name(new.__dict__.get(name_key, node.tag))
+        name = fix_name(new.__dict__.get(name_key, node.tag))
         parent.__dict__[name] = new
         return new
 

--- a/speasy/webservices/amda/utils.py
+++ b/speasy/webservices/amda/utils.py
@@ -43,7 +43,8 @@ def load_csv(filename: str) -> SpeasyVariable:
         columns = [col.strip() for col in meta['DATA_COLUMNS'].split(', ')[:]]
         with urlopen(filename) as f:
             data = pds.read_csv(f, comment='#', delim_whitespace=True, header=None, names=columns).values.transpose()
-        time, data = data[0], data[1:].transpose()
+        time, data = SpeasyVariable.epoch_to_datetime64(data[0]), data[1:].transpose()
+
         if "PARAMETER_TABLE_MIN_VALUES[1]" in meta:
             min_v = np.array([float(v) for v in meta["PARAMETER_TABLE_MIN_VALUES[1]"].split(',')])
             max_v = np.array([float(v) for v in meta["PARAMETER_TABLE_MAX_VALUES[1]"].split(',')])
@@ -94,7 +95,7 @@ def load_timetable(filename: str) -> TimeTable:
         return var
 
 
-def load_catalog(filename:str) -> Catalog:
+def load_catalog(filename: str) -> Catalog:
     """Load a timetable file
 
     Parameters

--- a/speasy/webservices/cda/__init__.py
+++ b/speasy/webservices/cda/__init__.py
@@ -8,13 +8,14 @@ __version__ = '0.1.0'
 
 from typing import Optional
 from datetime import datetime
-import pandas as pds
 from speasy.core.cache import Cacheable, CACHE_ALLOWED_KWARGS, _cache  # _cache is used for tests (hack...)
 from speasy.products.variable import SpeasyVariable
 from speasy.core import http, AllowedKwargs
 from speasy.core.proxy import Proxyfiable, GetProduct, PROXY_ALLOWED_KWARGS
-import numpy as np
+from speasy.core.cdf import load_variable
+from urllib.request import urlopen
 import logging
+from .indexes import to_dataset_and_variable
 
 log = logging.getLogger(__name__)
 
@@ -24,17 +25,9 @@ class CdaWebException(BaseException):
         super(CdaWebException, self).__init__(text)
 
 
-def _read_csv(url: str, *args, **kwargs) -> SpeasyVariable:
-    try:
-        df = pds.read_csv(url, comment='#', index_col=0, infer_datetime_format=True, parse_dates=True)
-        if df.index.tz is None:
-            df.index = df.index.tz_localize('UTC')
-        else:
-            df.index = df.index.tz_convert('UTC')
-        time = np.array([t.timestamp() for t in df.index])
-        return SpeasyVariable(time=time, data=df.values, columns=[c for c in df.columns])
-    except pds.io.common.EmptyDataError:
-        return SpeasyVariable()
+def _read_cdf(url: str, variable: str) -> SpeasyVariable:
+    with urlopen(url) as remote_cdf:
+        return load_variable(buffer=remote_cdf.read(), variable=variable)
 
 
 def get_parameter_args(start_time: datetime, stop_time: datetime, product: str, **kwargs):
@@ -46,73 +39,12 @@ class CDA_Webservice:
     def __init__(self):
         self.__url = "https://cdaweb.gsfc.nasa.gov/WS/cdasr/1"
 
-    def get_dataviews(self):
-        resp = http.get(self.__url + '/dataviews', headers={"Accept": "application/json"})
-        if not resp.ok:
-            return None
-        dataviews = [dv['Id'] for dv in resp.json()['DataviewDescription']]
-        return dataviews
-
-    def get_instruments(self, dataview='sp_phys', observatory=None, instrumentType=None):
-        args = []
-        if observatory is not None:
-            args.append(f'observatory={observatory}')
-        if instrumentType is not None:
-            args.append(f'instrumentType={instrumentType}')
-        resp = http.get(self.__url + f'/dataviews/{dataview}/instruments?' + "&".join(args),
-                        headers={"Accept": "application/json"})
-        if not resp.ok:
-            return None
-        instruments = [instrument for instrument in resp.json()['InstrumentDescription'] if
-                       instrument['Name'] != '']
-        return instruments
-
-    def get_datasets(self, dataview='sp_phys', observatoryGroup=None, instrumentType=None, observatory=None,
-                     instrument=None, startDate=None, stopDate=None, idPattern=None, labelPattern=None,
-                     notesPattern=None):
-        args = []
-        if observatory is not None:
-            args.append(f'observatory={observatory}')
-        if observatoryGroup is not None:
-            args.append(f'observatoryGroup={observatoryGroup}')
-        if instrumentType is not None:
-            args.append(f'instrumentType={instrumentType}')
-        if instrument is not None:
-            args.append(f'instrument={instrument}')
-        if startDate is not None:
-            args.append(f'startDate={startDate}')
-        if stopDate is not None:
-            args.append(f'stopDate={stopDate}')
-        if idPattern is not None:
-            args.append(f'idPattern={idPattern}')
-        if labelPattern is not None:
-            args.append(f'labelPattern={labelPattern}')
-        if notesPattern is not None:
-            args.append(f'notesPattern={notesPattern}')
-
-        resp = http.get(self.__url + f'/dataviews/{dataview}/datasets?' + "&".join(args),
-                        headers={"Accept": "application/json"})
-        if not resp.ok:
-            return None
-        datasets = [dataset for dataset in resp.json()['DatasetDescription']]
-        return datasets
-
-    def get_variables(self, dataset, dataview='sp_phys'):
-        resp = http.get(self.__url + f'/dataviews/{dataview}/datasets/{dataset}/variables',
-                        headers={"Accept": "application/json"})
-
-        if not resp.ok:
-            return None
-        variables = [varaible for varaible in resp.json()['VariableDescription']]
-        return variables
-
     def _dl_variable(self,
                      dataset: str, variable: str,
-                     start_time: datetime, stop_time: datetime, fmt: str = None) -> Optional[SpeasyVariable]:
+                     start_time: datetime, stop_time: datetime) -> Optional[SpeasyVariable]:
 
         start_time, stop_time = start_time.strftime('%Y%m%dT%H%M%SZ'), stop_time.strftime('%Y%m%dT%H%M%SZ')
-        loader = _read_csv
-        fmt = "csv"
+        fmt = "cdf"
         url = f"{self.__url}/dataviews/sp_phys/datasets/{dataset}/data/{start_time},{stop_time}/{variable}?format={fmt}"
         headers = {"Accept": "application/json"}
         log.debug(url)
@@ -121,15 +53,15 @@ class CDA_Webservice:
             raise CdaWebException(f'Failed to get data with request: {url}, got {resp.status_code} HTTP response')
         if not resp.ok or 'FileDescription' not in resp.json():
             return None
-        return loader(resp.json()['FileDescription'][0]['Name'], variable)
+        return _read_cdf(resp.json()['FileDescription'][0]['Name'], variable)
 
-    @AllowedKwargs(PROXY_ALLOWED_KWARGS + CACHE_ALLOWED_KWARGS + ['product', 'start_time', 'stop_time', 'fmt'])
+    @AllowedKwargs(PROXY_ALLOWED_KWARGS + CACHE_ALLOWED_KWARGS + ['product', 'start_time', 'stop_time'])
     @Cacheable(prefix="cda", fragment_hours=lambda x: 1)
     @Proxyfiable(GetProduct, get_parameter_args)
-    def get_data(self, product, start_time: datetime, stop_time: datetime, **kwargs):
-        components = product.split('/')
-        return self._dl_variable(start_time=start_time, stop_time=stop_time, dataset=components[0],
-                                 variable=components[1], **kwargs)
+    def get_data(self, product, start_time: datetime, stop_time: datetime):
+        dataset, variable = to_dataset_and_variable(product)
+        return self._dl_variable(start_time=start_time, stop_time=stop_time, dataset=dataset,
+                                 variable=variable)
 
     def get_variable(self, dataset: str, variable: str, start_time: datetime or str, stop_time: datetime or str,
                      **kwargs) -> \

--- a/speasy/webservices/cda/_inventory_builder/__init__.py
+++ b/speasy/webservices/cda/_inventory_builder/__init__.py
@@ -1,0 +1,59 @@
+from ._xml_catalogs_parser import load_xml_catalog
+from ._cdf_masters_parser import update_tree
+from ....core.index import index
+from ....config import cdaweb_inventory_data_path
+import requests
+from tempfile import NamedTemporaryFile
+import tarfile
+import os
+from glob import glob
+
+_MASTERS_CDF_PATH = f"{cdaweb_inventory_data_path.get()}/masters_cdf/"
+_XML_CATALOG_PATH = f"{cdaweb_inventory_data_path.get()}/all.xml"
+
+
+def _ensure_path_exists(path: str):
+    dirname = os.path.dirname(path)
+    if not os.path.exists(dirname):
+        os.makedirs(dirname)
+
+
+def _clean_master_cdf_folder():
+    _ensure_path_exists(_MASTERS_CDF_PATH)
+    cdf_files = glob(f"{_MASTERS_CDF_PATH}/*.cdf")
+    for cdf_file in cdf_files:
+        os.remove(cdf_file)
+
+
+def _download_and_extract_master_cdf(masters_url: str):
+    with NamedTemporaryFile('wb') as master_archive:
+        master_archive.write(requests.get(masters_url).content)
+        master_archive.flush()
+        tar = tarfile.open(master_archive.name)
+        tar.extractall(_MASTERS_CDF_PATH)
+
+
+def update_master_cdf(masters_url: str = "https://spdf.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/master.tar"):
+    last_modified = requests.head(masters_url).headers['last-modified']
+    if index.get("cdaweb-inventory", "masters-last-modified", "") != last_modified:
+        _clean_master_cdf_folder()
+        _download_and_extract_master_cdf(masters_url)
+        index.set("cdaweb-inventory", "masters-last-modified", last_modified)
+
+
+def update_xml_catalog(xml_catalog_url: str = "https://spdf.gsfc.nasa.gov/pub/catalogs/all.xml"):
+    last_modified = requests.head(xml_catalog_url).headers['last-modified']
+    if index.get("cdaweb-inventory", "xml_catalog-last-modified", "") != last_modified:
+        _ensure_path_exists(_XML_CATALOG_PATH)
+        with open(_XML_CATALOG_PATH, 'w') as f:
+            f.write(requests.get(xml_catalog_url).text)
+        index.set("cdaweb-inventory", "xml_catalog-last-modified", last_modified)
+
+
+def build_inventory(xml_catalog_url: str = "https://spdf.gsfc.nasa.gov/pub/catalogs/all.xml",
+                    masters_url: str = "https://spdf.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/master.tar"):
+    update_xml_catalog(xml_catalog_url)
+    t = load_xml_catalog(_XML_CATALOG_PATH)
+    update_master_cdf(masters_url)
+    update_tree(master_cdf_dir=_MASTERS_CDF_PATH)
+    return t

--- a/speasy/webservices/cda/_inventory_builder/_cdf_masters_parser.py
+++ b/speasy/webservices/cda/_inventory_builder/_cdf_masters_parser.py
@@ -1,0 +1,51 @@
+import os.path
+import logging
+import pyistp
+from speasy.inventory import flat_inventories
+from speasy.webservices.cda.indexes import CDAParameterIndex
+
+log = logging.getLogger(__name__)
+
+
+def extract_variable(variable):
+    return {
+        'shape': variable.shape[1:],
+        'attributes': {name: str(value) for name, value in variable.attrs.items()}
+    }
+
+
+def extract_variables(cdf):
+    return {
+        name: extract_variable(v) for name, v in cdf.items()
+    }
+
+
+def load_master_cdf(path, dataset):
+    skip_count = 0
+    try:
+        cdf = pyistp.load(path)
+        for name in cdf.data_variables():
+            try:
+                datavar = cdf.data_variable(name)
+                if datavar is not None:
+                    dataset.__dict__[name] = CDAParameterIndex(name=name, dataset=dataset.cda_id(),
+                                                               **datavar.attributes)
+            except IndexError or RuntimeError:
+                print(f"Issue loading {name} from {path}")
+                skip_count += 1
+    except RuntimeError:
+        print(f"Issue loading {name} from {path}")
+        skip_count += 1
+    return skip_count
+
+
+def update_tree(master_cdf_dir):
+    skip_count = 0
+    for dataset in flat_inventories.cda.datasets.values():
+        master_cdf_fname = dataset.mastercdf.split('/')[-1]
+        full_path = os.path.join(master_cdf_dir, master_cdf_fname)
+        if os.path.exists(full_path):
+            skip_count += load_master_cdf(full_path, dataset)
+        else:
+            skip_count += 1
+    print(f"{skip_count} datasets or variables skipped")

--- a/speasy/webservices/cda/_inventory_builder/_xml_catalogs_parser.py
+++ b/speasy/webservices/cda/_inventory_builder/_xml_catalogs_parser.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+from speasy.webservices.cda.indexes import CDAComponentIndex, CDADatasetIndex, CDAParameterIndex, CDAPathIndex
+from ._cdf_masters_parser import load_master_cdf
+from speasy.core import fix_name
+import xml.etree.ElementTree as Et
+
+
+def alias_rules(name):
+    rules = {
+        "AC": "ACE",
+        "Parker Solar Probe (PSP)": "ParkerSolarProbe",
+        "PSP": "ParkerSolarProbe",
+        "mms1": "MMS1",
+        "mms2": "MMS2",
+        "mms3": "MMS3",
+        "mms4": "MMS4",
+    }
+    return rules.get(name, name)
+
+
+def description(node) -> str:
+    desc_node = node.find('{cdas}description')
+    if desc_node is not None:
+        return desc_node.attrib['short']
+    return ""
+
+
+def make_inventory_node(inventory_node, ctor, name, *args, **kwargs):
+    if name not in inventory_node.__dict__:
+        inventory_node.__dict__[name] = ctor(name=name, *args, **kwargs)
+    return inventory_node.__dict__[name]
+
+
+def extract_node(node, is_dataset=False):
+    name = node.attrib["serviceprovider_ID"]
+    n = {
+        'name': fix_name(alias_rules(name)),
+        'description': description(node)
+    }
+    if is_dataset:
+        master_cd_node = node.find('{cdas}mastercdf')
+        if master_cd_node is not None:
+            n["mastercdf"] = master_cd_node.attrib["serviceprovider_ID"]
+    n.update(node.attrib)
+    return n
+
+
+def register_dataset(inventory_tree, mission_group_node, observatory_node, instrument_node, dataset_node):
+    observatory = extract_node(observatory_node)
+    mission_group = extract_node(mission_group_node)
+    if mission_group['name'] != observatory['name']:
+        inventory_tree = make_inventory_node(inventory_tree, CDAPathIndex, **mission_group)
+    inventory_tree = make_inventory_node(inventory_tree, CDAPathIndex, **observatory)
+    inventory_tree = make_inventory_node(inventory_tree, CDAPathIndex, **extract_node(instrument_node))
+    inventory_tree = make_inventory_node(inventory_tree, CDADatasetIndex, **extract_node(dataset_node, is_dataset=True))
+    return inventory_tree
+
+
+def has_master_cdf(node):
+    master_cdf = node.find('{cdas}mastercdf')
+    if master_cdf is not None:
+        return True
+    return None
+
+
+def parse_dataset(inventory_tree, dataset_node):
+    mission_group_node = dataset_node.find('{cdas}mission_group')
+    observatory_node = dataset_node.find('{cdas}observatory')
+    instrument_node = dataset_node.find('{cdas}instrument')
+    if has_master_cdf(dataset_node):
+        return register_dataset(inventory_tree, mission_group_node, observatory_node, instrument_node, dataset_node)
+    else:
+        print(f'Missing master CDF for {dataset_node.attrib["serviceprovider_ID"]}')
+
+
+def load_xml_catalog(xml_file_path: str):
+    with open(xml_file_path) as xml_file:
+        tree = Et.fromstring(xml_file.read())
+        inventory_tree = SimpleNamespace()
+        for site in tree.iter('{cdas}datasite'):
+            if site.attrib['ID'] == 'CDAWeb_HTTPS':
+                for node in site.iter('{cdas}dataset'):
+                    parse_dataset(inventory_tree, node)
+                return inventory_tree
+

--- a/speasy/webservices/cda/indexes.py
+++ b/speasy/webservices/cda/indexes.py
@@ -1,0 +1,64 @@
+from typing import Tuple
+from types import SimpleNamespace
+from speasy.inventory.indexes import ParameterIndex, DatasetIndex, ComponentIndex
+from speasy.inventory import flat_inventories
+
+
+class CDAIndex:
+    def __init__(self, id: str):
+        self._id = id
+
+    def dl_kw_args(self):
+        return {'xmlid': self._id}
+
+    def cda_id(self):
+        return self._id
+
+
+class CDAPathIndex(SimpleNamespace):
+    def __init__(self, **meta):
+        super().__init__(**meta)
+
+
+class CDAComponentIndex(CDAIndex, ComponentIndex):  # lgtm [py/conflicting-attributes]
+    def __init__(self, **meta):
+        _id = meta.pop('serviceprovider_ID')
+        name = meta.pop('name')
+        ComponentIndex.__init__(self=self, name=name, provider="cdaweb", meta=meta)
+        CDAIndex.__init__(self=self, id=_id)
+        flat_inventories.cda.components[_id] = self
+
+
+class CDAParameterIndex(CDAIndex, ParameterIndex):  # lgtm [py/conflicting-attributes]
+    def __init__(self, name, dataset, **meta):
+        name = name
+        self.dataset = dataset
+        ParameterIndex.__init__(self=self, name=name, provider="cdaweb", meta=meta)
+        CDAIndex.__init__(self=self, id=name)
+        flat_inventories.cda.parameters[name] = self
+
+    def product(self):
+        return f"{self.dataset}/{self.name}"
+
+
+class CDADatasetIndex(CDAIndex, DatasetIndex):  # lgtm [py/conflicting-attributes]
+
+    def __init__(self, **meta):
+        id = meta.pop('serviceprovider_ID')
+        name = meta.pop('name')
+        DatasetIndex.__init__(self=self, name=name, provider="cdaweb", meta=meta)
+        CDAIndex.__init__(self=self, id=id)
+        flat_inventories.cda.datasets[id] = self
+
+
+def to_dataset_and_variable(index_or_str: CDAParameterIndex or str) -> Tuple[str, str]:
+    if type(index_or_str) is str:
+        parts = index_or_str.split('/')
+        assert len(parts) == 2
+        return parts[0], parts[1]
+    if type(index_or_str) is CDAParameterIndex:
+        parts = index_or_str.product().split('/')
+        assert len(parts) == 2
+        return parts[0], parts[1]
+    else:
+        raise TypeError(f"given parameter {index_or_str} of type {type(index_or_str)} is not a compatible index")

--- a/speasy/webservices/cda/inventory.py
+++ b/speasy/webservices/cda/inventory.py
@@ -1,0 +1,10 @@
+"""Base inventory tree management
+"""
+from types import SimpleNamespace
+from .indexes import CDAComponentIndex, CDADatasetIndex, CDAParameterIndex
+import xml.etree.ElementTree as Et
+
+
+
+
+

--- a/speasy/webservices/ssc/__init__.py
+++ b/speasy/webservices/ssc/__init__.py
@@ -23,12 +23,12 @@ import logging
 log = logging.getLogger(__name__)
 
 
-def _make_datetime(dt: str) -> datetime:
+def _make_datetime(dt: str) -> np.datetime64:
     '''
         Hack to support python 3.6, once 3.6 support removed then go back to:
         datetime.strptime(v[1], '%Y-%m-%dT%H:%M:%S.%f%z').timestamp()
     '''
-    return datetime(*time.strptime(dt[:-6], '%Y-%m-%dT%H:%M:%S.%f')[:6], tzinfo=timezone.utc).timestamp()
+    return np.datetime64(dt[:-6], 'ns')
 
 
 def _variable(orbit: dict) -> Optional[SpeasyVariable]:

--- a/tests/test_amda_parameter.py
+++ b/tests/test_amda_parameter.py
@@ -5,6 +5,9 @@
 
 import unittest
 from datetime import datetime, timedelta
+
+import numpy as np
+
 import speasy as spz
 from speasy.products.variable import SpeasyVariable
 
@@ -34,14 +37,16 @@ class ParameterRequests(unittest.TestCase):
         self.assertTrue(self.data.values.shape[0] == self.data.time.shape[0])
 
     def test_time_datatype(self):
-        self.assertTrue(self.data.time.dtype == float)
+        self.assertTrue(self.data.time.dtype == np.dtype('datetime64[ns]'))
 
     def test_time_range(self):
         min_dt = min(self.data.time[1:] - self.data.time[:-1])
+        start = np.datetime64(self.start, 'ns')
+        stop = np.datetime64(self.stop, 'ns')
         self.assertTrue(
-            self.start <= datetime.utcfromtimestamp(self.data.time[0]) < self.start + timedelta(seconds=min_dt))
+            start <= self.data.time[0] < (start + min_dt))
         self.assertTrue(
-            self.stop > datetime.utcfromtimestamp(self.data.time[-1]) >= self.stop - timedelta(seconds=min_dt))
+            stop > self.data.time[-1] >= (stop - min_dt))
 
     def test_dataset_not_none(self):
         self.assertIsNotNone(self.dataset)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -35,13 +35,13 @@ class _CacheTest(unittest.TestCase):
              range(int((stop_time - start_time).seconds / 60))])
         data = index / 3600.
         self._make_data_cntr += 1
-        return SpeasyVariable(time=index, data=data)
+        return SpeasyVariable(time=SpeasyVariable.epoch_to_datetime64(index), data=data)
 
     def _get_and_check(self, start, stop):
         var = self._make_data("...", start, stop)
         self.assertIsNotNone(var)
-        self.assertEqual(var.time[0], start.timestamp())
-        self.assertEqual(var.time[-1], (stop - timedelta(minutes=1)).timestamp())
+        self.assertEqual(var.time[0], np.datetime64(start, 'ns'))
+        self.assertEqual(var.time[-1], np.datetime64(stop - timedelta(minutes=1), 'ns'))
         self.assertEqual(len(var), (stop - start).seconds / 60)
 
     @data(

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -60,7 +60,7 @@ class ConcurrentRequests(unittest.TestCase):
             return self.cd.get_variable(dataset="MMS2_SCM_SRVY_L2_SCSRVY", variable="mms2_scm_acb_gse_scsrvy_srvy_l2",
                                         start_time=datetime(2016, 6, 1, 0, 10, tzinfo=timezone.utc),
                                         stop_time=datetime(2016, 6, 1, 0, 20, tzinfo=timezone.utc), disable_proxy=True,
-                                        disable_cache=True, fmt="csv")
+                                        disable_cache=True)
 
         with dummy.Pool(6) as pool:
             results = pool.map(func, [1] * 10)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -9,7 +9,8 @@ import numpy as np
 def make_simple_var(start: float = 0., stop: float = 0., step: float = 1., coef: float = 1.):
     time = np.arange(start, stop, step)
     values = time * coef
-    return SpeasyVariable(time=time, data=values, meta=None, columns=["Values"], y=None)
+    return SpeasyVariable(time=SpeasyVariable.epoch_to_datetime64(time), data=values, meta=None, columns=["Values"],
+                          y=None)
 
 
 class SpeasyDataset(unittest.TestCase):

--- a/tests/test_spwc.py
+++ b/tests/test_spwc.py
@@ -11,11 +11,12 @@ from ddt import ddt, data
 @ddt
 class GetSpwc(unittest.TestCase):
     def setUp(self):
+        self.proxy_state = spz.config.proxy_enabled.get()
         spz.config.proxy_enabled.set("true")
         spz.config.proxy_url.set("http://sciqlop.lpp.polytechnique.fr/cache")
 
     def tearDown(self):
-        pass
+        spz.config.proxy_enabled.set(self.proxy_state)
 
     @data(
         {

--- a/tests/test_sscweb.py
+++ b/tests/test_sscweb.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from speasy.webservices import ssc
 from astropy import units
 from ddt import ddt, data
+import numpy as np
 
 
 @ddt
@@ -63,8 +64,8 @@ class SscWeb(unittest.TestCase):
                                          disable_proxy=True)
         self.assertIsNotNone(result)
         self.assertGreater(len(result), 0)
-        self.assertGreater(60., kw["start_time"].timestamp() - result.time[0])
-        self.assertGreater(60., kw["stop_time"].timestamp() - result.time[-1])
+        self.assertGreater(np.timedelta64(60, 's'), np.datetime64(kw["start_time"], 'ns') - result.time[0])
+        self.assertGreater(np.timedelta64(60, 's'), np.datetime64(kw["stop_time"], 'ns') - result.time[-1])
 
     def test_get_data_from_cache_preserve_unit(self):
         # https://github.com/SciQLop/speasy/issues/7

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36, py37, py38, py39, py310, flake8
+envlist = py37, py38, py39, py310, flake8
 
 [travis]
 python =


### PR DESCRIPTION
Most necessary work for CDA support in Speasy.
This PR basically:
- changes Speasy time index from float to numpy datetime64(ns)  *breaks cache backward compatibility*
- adds ISTP CDF files loading support
- introduces an Index object to provide simple dictionary like persistent storage (like cache but without eviction policy)
- forces CDA webservice impl to request CDF files
- provides bits to build CDA inventory (will mostly be used on proxy side)

Closes #43, closes #28