### PR TITLE
Forces inventory build tests on CI and fixes a bug with CDA inventory

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -42,11 +42,15 @@ jobs:
         pytest
     - name: Test with pytest (coverage + long tests)
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
+      env:
+        SPEASY_AMDA_MAX_CHUNK_SIZE_DAYS: "25"
+        SPEASY_LONG_TESTS: ""
+        SPEASY_INVENTORY_TESTS: ""
       run: |
         sudo apt update && sudo apt install -y texlive pandoc
         pip install pytest pytest-cov sphinx pandoc
         pip install -r docs/requirements.txt
-        SPEASY_AMDA_MAX_CHUNK_SIZE_DAYS=25 SPEASY_LONG_TESTS="" pytest --cov=./ --cov-report=xml
+        pytest --cov=./ --cov-report=xml
         make doctest
     - name: Check that release process is not broken
       if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,11 +42,15 @@ jobs:
         pytest
     - name: Test with pytest (coverage + long tests)
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'
+      env:
+        SPEASY_AMDA_MAX_CHUNK_SIZE_DAYS: "25"
+        SPEASY_LONG_TESTS: ""
+        SPEASY_INVENTORY_TESTS: ""
       run: |
         sudo apt update && sudo apt install -y texlive pandoc
         pip install pytest pytest-cov sphinx pandoc
         pip install -r docs/requirements.txt
-        SPEASY_AMDA_MAX_CHUNK_SIZE_DAYS=25 SPEASY_LONG_TESTS="" pytest --cov=./ --cov-report=xml
+        pytest --cov=./ --cov-report=xml
         make doctest
     - name: Check that release process is not broken
       if: matrix.python-version == '3.7' && matrix.os == 'ubuntu-latest'

--- a/speasy/core/__init__.py
+++ b/speasy/core/__init__.py
@@ -272,6 +272,7 @@ def fix_name(name: str):
             if bad in name:
                 name = name.replace(bad, replacement)
         return name
+    raise ValueError("Got empty name")
 
 
 def progress_bar(leave=True, progress=False, desc=None, **kwargs):

--- a/speasy/webservices/cda/_inventory_builder/_xml_catalogs_parser.py
+++ b/speasy/webservices/cda/_inventory_builder/_xml_catalogs_parser.py
@@ -47,8 +47,9 @@ def register_dataset(inventory_tree, mission_group_node, observatory_node, instr
                                              uid=mission_group.get('serviceprovider_ID'), **mission_group)
     inventory_tree = make_inventory_node(inventory_tree, SpeasyIndex, provider="cda",
                                          uid=observatory.get('serviceprovider_ID'), **observatory)
-    inventory_tree = make_inventory_node(inventory_tree, SpeasyIndex, provider="cda",
-                                         uid=instrument_node.get('serviceprovider_ID'), **extract_node(instrument_node))
+    if instrument_node.attrib["serviceprovider_ID"] != "":
+        inventory_tree = make_inventory_node(inventory_tree, SpeasyIndex, provider="cda",
+                                             uid=instrument_node.get('serviceprovider_ID'), **extract_node(instrument_node))
     inventory_tree = make_inventory_node(inventory_tree, DatasetIndex, provider="cda",
                                          uid=dataset_node.get('serviceprovider_ID'),
                                          **extract_node(dataset_node, is_dataset=True))

--- a/tests/test_speasy.py
+++ b/tests/test_speasy.py
@@ -129,13 +129,27 @@ class SpeasyModule(unittest.TestCase):
         self.assertGreaterEqual(
             len(spz.inventories.flat_inventories.__dict__[provider].parameters), 1)
 
-    def test_can_update_inventories_all_at_once(self):
+    def test_can_update_inventories_all_at_once_from_proxy(self):
         for provider in PROVIDERS.keys():
             spz.inventories.flat_inventories.__dict__[
                 provider].parameters.clear()
 
         spz.update_inventories()
 
+        for provider in PROVIDERS.keys():
+            self.assertGreaterEqual(
+                len(spz.inventories.flat_inventories.__dict__[provider].parameters), 1)
+    
+    def test_can_update_inventories_all_at_once_without_proxy(self):
+        if "SPEASY_INVENTORY_TESTS" not in os.environ:
+            self.skipTest("Inventory tests disabled")
+        for provider in PROVIDERS.keys():
+            spz.inventories.flat_inventories.__dict__[
+                provider].parameters.clear()
+
+        os.environ[spz.config.proxy.enabled.env_var_name] = "False"
+        spz.update_inventories()
+        os.environ.pop(spz.config.proxy.enabled.env_var_name)
         for provider in PROVIDERS.keys():
             self.assertGreaterEqual(
                 len(spz.inventories.flat_inventories.__dict__[provider].parameters), 1)


### PR DESCRIPTION
It seems that some instruments nodes names are empty so just skip them and just directly add datasets nodes into parent node.

It might not be enough to cover all cases, a more systematic analysis might be required to spot all "broken nodes".