### PR TITLE
Adds option to disable webservices, closes #64

### DIFF
--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -143,6 +143,13 @@ def remove_entry(entry: ConfigEntry):
 #                           ADD HERE CONFIG ENTRIES
 # user can easily discover them with speasy.config.<completion>
 # ==========================================================================================
+core = ConfigSection("CORE",
+                     disabled_providers={"default": set(),
+                                         "description": """A comma separated list of providers you want to disable.
+The main benefit of disabling providers is to speedup speasy loading.""",
+                                         "type_ctor": lambda x: set(x.split(','))}
+                     )
+
 proxy = ConfigSection("PROXY",
                       enabled={"default": True,
                                "description": """Enables or disables speasy proxy usage.

--- a/tests/test_disable_ws.py
+++ b/tests/test_disable_ws.py
@@ -1,0 +1,39 @@
+import unittest
+
+import os
+import sys
+
+
+def _drop_all_speazy_mods():
+    keys = list(sys.modules.keys())
+    for name in keys:
+        if 'speasy' in name:
+            sys.modules.pop(name)
+
+
+class DisableWS(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_disable_amda(self):
+        os.environ["SPEASY_CORE_DISABLED_PROVIDERS"] = "amda"
+        _drop_all_speazy_mods()
+        import speasy as spz
+        self.assertNotIn("amda", spz.inventories.tree.__dict__)
+        self.assertIsNone(spz.amda)
+        self.assertIn("cda", spz.inventories.tree.__dict__)
+        self.assertIsNotNone(spz.cda)
+
+    def test_disable_ssc_and_cda(self):
+        os.environ["SPEASY_CORE_DISABLED_PROVIDERS"] = "ssc,cda"
+        _drop_all_speazy_mods()
+        import speasy as spz
+        self.assertNotIn("ssc", spz.inventories.tree.__dict__)
+        self.assertIsNone(spz.ssc)
+        self.assertNotIn("cda", spz.inventories.tree.__dict__)
+        self.assertIsNone(spz.cda)
+        self.assertIn("amda", spz.inventories.tree.__dict__)
+        self.assertIsNotNone(spz.amda)

--- a/tests/test_speasy.py
+++ b/tests/test_speasy.py
@@ -118,7 +118,7 @@ class SpeasyModule(unittest.TestCase):
     def test_can_list_providers(self):
         l = spz.list_providers()
         self.assertListEqual(
-            l, ['amda', 'cdaweb', 'cda', 'sscweb', 'ssc', 'csa'])
+            sorted(l), sorted(['amda', 'cdaweb', 'cda', 'sscweb', 'ssc', 'csa']))
 
     @data(*[(provider,) for provider in PROVIDERS.keys()])
     @unpack

--- a/tests/test_zzz_disable_ws.py
+++ b/tests/test_zzz_disable_ws.py
@@ -1,14 +1,14 @@
 import unittest
-
+import importlib
 import os
 import sys
 
 
-def _drop_all_speazy_mods():
+def _reload_all_speazy_mods():
     keys = list(sys.modules.keys())
     for name in keys:
-        if 'speasy' in name:
-            sys.modules.pop(name)
+        if any(map(name.startswith, ('speasy', 'diskcache', 'pickle'))):
+            sys.modules[name] = importlib.reload(sys.modules[name])
 
 
 class DisableWS(unittest.TestCase):
@@ -16,11 +16,12 @@ class DisableWS(unittest.TestCase):
         pass
 
     def tearDown(self):
-        pass
+        os.environ.pop("SPEASY_CORE_DISABLED_PROVIDERS")
+        _reload_all_speazy_mods()
 
     def test_disable_amda(self):
         os.environ["SPEASY_CORE_DISABLED_PROVIDERS"] = "amda"
-        _drop_all_speazy_mods()
+        _reload_all_speazy_mods()
         import speasy as spz
         self.assertNotIn("amda", spz.inventories.tree.__dict__)
         self.assertIsNone(spz.amda)
@@ -29,7 +30,7 @@ class DisableWS(unittest.TestCase):
 
     def test_disable_ssc_and_cda(self):
         os.environ["SPEASY_CORE_DISABLED_PROVIDERS"] = "ssc,cda"
-        _drop_all_speazy_mods()
+        _reload_all_speazy_mods()
         import speasy as spz
         self.assertNotIn("ssc", spz.inventories.tree.__dict__)
         self.assertIsNone(spz.ssc)


### PR DESCRIPTION
This adds an undocumented option to disable any web-service support in speasy. 
As discussed in meeting, this will speedup speasy loading for use-cases where only one web-service is used.