### PR TITLE
Fix bug #75

### DIFF
--- a/speasy/core/cache/_providers_caches.py
+++ b/speasy/core/cache/_providers_caches.py
@@ -109,7 +109,11 @@ class _Cacheable:
         entry = self.get_cache_entry(fragment, product, **kwargs)
         if entry is not None:
             if is_up_to_date(entry, version):
-                return from_dictionary(entry.data)
+                try:
+                    return from_dictionary(entry.data)
+                except Exception as e:
+                    log.warning(f"got an exception {e} while loading fragment {fragment} for {product}")
+                    return None
             log.debug(f"Cache entry is outdated")
         return None
 
@@ -205,7 +209,11 @@ class UnversionedProviderCache(object):
             if entry is None:
                 missing_fragments.append(fragment)
             elif (entry.version + self.cache_retention) > datetime.utcnow():
-                data_chunks.append(from_dictionary(entry.data))
+                try:
+                    data_chunks.append(from_dictionary(entry.data))
+                except Exception as e:
+                    missing_fragments.append(fragment)
+                    log.warning(f"got an exception {e} while loading fragment {fragment} for {product}")
             else:
                 maybe_outdated_fragments.append((fragment, entry))
 

--- a/speasy/core/data_containers.py
+++ b/speasy/core/data_containers.py
@@ -74,9 +74,14 @@ class DataContainer(object):
 
     @staticmethod
     def from_dictionary(dictionary: Dict[str, str or Dict[str, str] or List], dtype=np.float) -> "DataContainer":
-        return DataContainer(values=np.array(dictionary["values"], dtype=dtype), meta=dictionary["meta"],
-                             name=dictionary["name"],
-                             is_time_dependent=dictionary["is_time_dependent"])
+        try:
+            return DataContainer(values=np.array(dictionary["values"], dtype=dtype), meta=dictionary["meta"],
+                                 name=dictionary["name"],
+                                 is_time_dependent=dictionary["is_time_dependent"])
+        except ValueError:
+            return DataContainer(values=np.array(dictionary["values"]), meta=dictionary["meta"],
+                                 name=dictionary["name"],
+                                 is_time_dependent=dictionary["is_time_dependent"])
 
     @staticmethod
     def reserve_like(other: 'DataContainer', length: int = 0) -> 'DataContainer':
@@ -98,10 +103,10 @@ class DataContainer(object):
 
     def __eq__(self, other: 'DataContainer') -> bool:
         return self.__meta == other.__meta and \
-            self.__name == other.__name and \
-            self.is_time_dependent == other.is_time_dependent and \
-            np.all(self.__values.shape == other.__values.shape) and \
-            np.array_equal(self.__values, other.__values, equal_nan=True)
+               self.__name == other.__name and \
+               self.is_time_dependent == other.is_time_dependent and \
+               np.all(self.__values.shape == other.__values.shape) and \
+               np.array_equal(self.__values, other.__values, equal_nan=True)
 
     def replace_val_by_nan(self, val):
         if self.__values.dtype != np.float:

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -140,5 +140,13 @@ class ConcurrentRequests(unittest.TestCase):
             self.assertIsNotNone(result)
 
 
+class SpecificNonRegression(unittest.TestCase):
+
+    def test_broken_var_saved_into_cache(self):
+        for i in range(2):
+            v = spz.get_data(spz.inventories.tree.cda.ACE.MAG.AC_H2_MFI.BGSEc, "2018-01-01", "2018-01-02")
+            self.assertIsNotNone(v)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR covers both issues described in #75 , first when we fail to load a cache fragment, we just continue and get corresponding data as if it never was in cache. Then there was an assumption that all axes values were numerical, let's just support the case where we can also get pure text in axes data.