### PR TITLE
Reduces requests size for MMS big burst products on CDAWeb

### DIFF
--- a/speasy/core/inventory/indexes.py
+++ b/speasy/core/inventory/indexes.py
@@ -1,5 +1,5 @@
-from typing import Optional
 import json
+from typing import Optional
 
 __INDEXES_TYPES__ = {}
 
@@ -78,8 +78,12 @@ class ParameterIndex(SpeasyIndex):
 
     def __contains__(self, item: str or ComponentIndex):
         if type(item) is ComponentIndex:
-            item = item.name()
-        return item in self.__dict__
+            item = item.spz_uid()
+        for member in self.__dict__.values():
+            if isinstance(member, ComponentIndex):
+                if member.spz_uid() == item:
+                    return True
+        return False
 
 
 class DatasetIndex(SpeasyIndex):
@@ -94,8 +98,12 @@ class DatasetIndex(SpeasyIndex):
 
     def __contains__(self, item: str or ParameterIndex):
         if type(item) is ParameterIndex:
-            item = item.name()
-        return item in self.__dict__
+            item = item.spz_uid()
+        for member in self.__dict__.values():
+            if isinstance(member, ParameterIndex):
+                if member.spz_uid() == item:
+                    return True
+        return False
 
 
 def to_dict(inventory_tree: SpeasyIndex or str):

--- a/speasy/core/requests_scheduling/split_large_requests.py
+++ b/speasy/core/requests_scheduling/split_large_requests.py
@@ -1,12 +1,14 @@
-from typing import Callable
-from speasy.core.datetime_range import DateTimeRange
 from datetime import timedelta
 from functools import wraps
+from typing import Callable
+
+from speasy.core.datetime_range import DateTimeRange
+from speasy.core.inventory.indexes import ParameterIndex
 from speasy.products.variable import merge as var_merge
 
 
 class SplitLargeRequests(object):
-    def __init__(self, threshold: Callable[[], timedelta]):
+    def __init__(self, threshold: Callable[[ParameterIndex or str], timedelta]):
         self.threshold = threshold
 
     def __call__(self, get_data: Callable):
@@ -14,7 +16,7 @@ class SplitLargeRequests(object):
         def wrapped(wrapped_self, product, start_time, stop_time, **kwargs):
             range = DateTimeRange(start_time, stop_time)
             duration = range.duration
-            max_range_per_request = self.threshold()
+            max_range_per_request = self.threshold(product)
             if duration <= max_range_per_request:
                 return get_data(wrapped_self, product=product, start_time=start_time, stop_time=stop_time, **kwargs)
             else:

--- a/speasy/webservices/cda/__init__.py
+++ b/speasy/webservices/cda/__init__.py
@@ -148,7 +148,7 @@ class CDA_Webservice(DataProvider):
         PROXY_ALLOWED_KWARGS + CACHE_ALLOWED_KWARGS + GET_DATA_ALLOWED_KWARGS + ['if_newer_than'])
     @ParameterRangeCheck()
     @UnversionedProviderCache(prefix="cda", fragment_hours=lambda x: 12, cache_retention=timedelta(days=7))
-    @SplitLargeRequests(threshold=lambda: timedelta(days=7))
+    @SplitLargeRequests(threshold=lambda x: timedelta(days=7))
     @Proxyfiable(GetProduct, get_parameter_args)
     def get_data(self, product, start_time: datetime, stop_time: datetime, if_newer_than: datetime or None = None,
                  extra_http_headers: Dict or None = None):

--- a/speasy/webservices/csa/__init__.py
+++ b/speasy/webservices/csa/__init__.py
@@ -1,20 +1,22 @@
+import logging
+import tarfile
+from datetime import datetime, timedelta
+from io import BytesIO
+from tempfile import TemporaryDirectory
+from typing import Optional, Tuple, Dict
+
 import requests
 from astroquery.utils.tap.core import TapPlus
-from typing import Optional, Tuple, Dict
-from datetime import datetime, timedelta
-from speasy.core.cache import Cacheable, CACHE_ALLOWED_KWARGS  # _cache is used for tests (hack...)
-from speasy.products.variable import SpeasyVariable
+
 from speasy.core import http, AllowedKwargs, fix_name
-from speasy.core.proxy import Proxyfiable, GetProduct, PROXY_ALLOWED_KWARGS
+from speasy.core.cache import Cacheable, CACHE_ALLOWED_KWARGS  # _cache is used for tests (hack...)
 from speasy.core.cdf import load_variable
-from speasy.core.inventory.indexes import ParameterIndex, DatasetIndex, SpeasyIndex, make_inventory_node
 from speasy.core.dataprovider import DataProvider, ParameterRangeCheck, GET_DATA_ALLOWED_KWARGS
-from tempfile import TemporaryDirectory
 from speasy.core.datetime_range import DateTimeRange
+from speasy.core.inventory.indexes import ParameterIndex, DatasetIndex, SpeasyIndex, make_inventory_node
+from speasy.core.proxy import Proxyfiable, GetProduct, PROXY_ALLOWED_KWARGS
 from speasy.core.requests_scheduling import SplitLargeRequests
-import tarfile
-import logging
-from io import BytesIO
+from speasy.products.variable import SpeasyVariable
 
 log = logging.getLogger(__name__)
 
@@ -223,7 +225,7 @@ class CSA_Webservice(DataProvider):
     @AllowedKwargs(PROXY_ALLOWED_KWARGS + CACHE_ALLOWED_KWARGS + GET_DATA_ALLOWED_KWARGS)
     @ParameterRangeCheck()
     @Cacheable(prefix="csa", fragment_hours=lambda x: 12, version=product_last_update)
-    @SplitLargeRequests(threshold=lambda: timedelta(days=7))
+    @SplitLargeRequests(threshold=lambda x: timedelta(days=7))
     @Proxyfiable(GetProduct, get_parameter_args)
     def get_data(self, product, start_time: datetime, stop_time: datetime,
                  extra_http_headers: Dict[str, str] or None = None):

--- a/speasy/webservices/ssc/__init__.py
+++ b/speasy/webservices/ssc/__init__.py
@@ -6,20 +6,20 @@ __author__ = """Alexis Jeandet"""
 __email__ = 'alexis.jeandet@member.fsf.org'
 __version__ = '0.1.0'
 
-from typing import Optional, Dict
+import logging
 from datetime import datetime, timedelta
+from typing import Optional, Dict
+
+import numpy as np
+
 from speasy.core.cache import Cacheable, CacheCall, CACHE_ALLOWED_KWARGS
-from speasy.products.variable import SpeasyVariable, VariableTimeAxis, DataContainer
-from ...core import http, AllowedKwargs, deprecation
-from speasy.core.proxy import Proxyfiable, GetProduct, PROXY_ALLOWED_KWARGS
-from speasy.core.inventory.indexes import ParameterIndex, SpeasyIndex
 from speasy.core.dataprovider import DataProvider, ParameterRangeCheck, GET_DATA_ALLOWED_KWARGS
 from speasy.core.datetime_range import DateTimeRange
+from speasy.core.inventory.indexes import ParameterIndex, SpeasyIndex
+from speasy.core.proxy import Proxyfiable, GetProduct, PROXY_ALLOWED_KWARGS
 from speasy.core.requests_scheduling import SplitLargeRequests
-import numpy as np
-from astropy import units
-
-import logging
+from speasy.products.variable import SpeasyVariable, VariableTimeAxis, DataContainer
+from ...core import http, AllowedKwargs
 
 log = logging.getLogger(__name__)
 
@@ -123,7 +123,7 @@ class SSC_Webservice(DataProvider):
                                                                                  'debug'])
     @ParameterRangeCheck()
     @Cacheable(prefix="ssc_orbits", fragment_hours=lambda x: 24, version=version, entry_name=_make_cache_entry_name)
-    @SplitLargeRequests(threshold=lambda: timedelta(days=60))
+    @SplitLargeRequests(threshold=lambda x: timedelta(days=60))
     @Proxyfiable(GetProduct, get_parameter_args)
     def _get_orbit(self, product: str, start_time: datetime, stop_time: datetime, coordinate_system: str = 'gse',
                    debug=False, extra_http_headers: Dict or None = None) -> Optional[SpeasyVariable]:

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -34,6 +34,12 @@ class SimpleRequest(unittest.TestCase):
             "variable": "C/O_ratio",
             "start_time": datetime(1996, 8, 1, 20, tzinfo=timezone.utc),
             "stop_time": datetime(1996, 8, 1, 23, tzinfo=timezone.utc)
+        },
+        {
+            "dataset": "MMS1_SCM_BRST_L2_SCB",
+            "variable": "mms1_scm_acb_gse_scb_brst_l2",
+            "start_time": datetime(2020, 1, 1, tzinfo=timezone.utc),
+            "stop_time": datetime(2020, 1, 1, 2, tzinfo=timezone.utc)
         }
     )
     def test_get_variable(self, kw):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -3,9 +3,10 @@
 
 """Tests for `speasy.common` package."""
 import unittest
+
 from ddt import ddt, data, unpack
 
-import speasy.core
+import speasy as spz
 
 
 @ddt
@@ -23,4 +24,32 @@ class Listify(unittest.TestCase):
     )
     @unpack
     def test_listify(self, input, expected):
-        self.assertEqual(speasy.core.listify(input), expected)
+        self.assertEqual(spz.core.listify(input), expected)
+
+
+class Indexes(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_parameter_index_contains_component(self):
+        self.assertIn(spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all.imf_gsm.imf_gsm0,
+                      spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all.imf_gsm)
+
+        self.assertNotIn(spz.inventories.tree.amda.Parameters.ACE.MFI.ace_mag_real.imf_real_gse.imf_real_gse1,
+                         spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all.imf_gsm)
+
+        self.assertNotIn("random name that is not a component",
+                         spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all.imf_gsm)
+
+    def test_dataset_index_contains_parameter(self):
+        self.assertIn(spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all.imf_gsm,
+                      spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all)
+
+        self.assertNotIn(spz.inventories.tree.amda.Parameters.ACE.MFI.ace_mag_real.imf_real_gse,
+                         spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all)
+
+        self.assertNotIn("random name that is not a parameter",
+                         spz.inventories.tree.amda.Parameters.ACE.MFI.ace_imf_all)


### PR DESCRIPTION
Mostly allow to define some products that needs a smaller max request size and cache entry size.

This solves the issue with some MMS products that are too big on CDAWeb to be downloaded in more than few hours batches.