### PR TITLE
Fixes AMDA CSV parser where derived parameters attributes gets overwritten by base param

### DIFF
--- a/speasy/webservices/amda/_impl.py
+++ b/speasy/webservices/amda/_impl.py
@@ -3,19 +3,19 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Dict, Optional
 
-# General modules
-from ...config import amda as amda_cfg
-from ...core.cache import CacheCall
-from ...core.http import urlopen_with_retry
-from ...core.inventory.indexes import SpeasyIndex
-from ...core.cdf import load_variable as load_cdf
-from ...inventories import flat_inventories
-from ...products.variable import SpeasyVariable, merge
 from . import rest_client
 from .exceptions import MissingCredentials
 from .inventory import AmdaXMLParser
 from .rest_client import auth_args
 from .utils import load_catalog, load_csv, load_timetable
+# General modules
+from ...config import amda as amda_cfg
+from ...core.cache import CacheCall
+from ...core.cdf import load_variable as load_cdf
+from ...core.http import urlopen_with_retry
+from ...core.inventory.indexes import SpeasyIndex
+from ...inventories import flat_inventories
+from ...products.variable import SpeasyVariable, merge
 
 log = logging.getLogger(__name__)
 
@@ -106,7 +106,7 @@ class AmdaImpl:
                     with urlopen_with_retry(url) as remote_cdf:
                         var = load_cdf(buffer=remote_cdf.read(), variable=parameter_id)
             else:
-                var = load_csv(url)
+                var = load_csv(url, parameter_id)
             if len(var):
                 log.debug(
                     f'Loaded var: data shape = {var.values.shape}, data start time = {var.time[0]}, \

--- a/speasy/webservices/amda/utils.py
+++ b/speasy/webservices/amda/utils.py
@@ -70,8 +70,9 @@ def load_csv(filename: str) -> SpeasyVariable:
             y_label = None
             while len(line) > 0 and line[0] == '#':
                 if ':' in line:
-                    key, value = line[1:].split(':', 1)
-                    meta[key.strip()] = value.strip()
+                    key, value = [v.strip() for v in line[1:].split(':', 1)]
+                    if key not in meta:
+                        meta[key] = value
                 line = fd.readline().decode()
             columns = [col.strip()
                        for col in meta.get('DATA_COLUMNS', "").split(', ')[:]]

--- a/speasy/webservices/amda/utils.py
+++ b/speasy/webservices/amda/utils.py
@@ -47,7 +47,8 @@ def _copy_data(csv, fd):
     return fd
 
 
-_parameters_header_blocks_regex = re.compile("(# *PARAMETER_ID : ([^\n]+)\n(# *[A-Z_]+ : [^\n]+\n)+)+")
+_parameters_header_blocks_regex = re.compile(
+    f"(# *PARAMETER_ID : ([^{os.linesep}]+){os.linesep}(# *[A-Z_]+ : [^{os.linesep}]+{os.linesep})+)+")
 
 
 def _parse_header(fd, expected_parameter: str):

--- a/tests/resources/derived_param.txt
+++ b/tests/resources/derived_param.txt
@@ -1,0 +1,63 @@
+# -----------
+# AMDA INFO :
+# -----------
+# AMDA_ABOUT : Created by AMDA
+# AMDA_VERSION : 3.6.5
+# AMDA_ACKNOWLEDGEMENT : CDPP/AMDA Team
+#
+# --------------
+# REQUEST INFO :
+# --------------
+# REQUEST_STRUCTURE : all-in-one-file-refparam
+# REQUEST_TIME_FORMAT : Seconds from 1970, milliseconds
+# REQUEST_OUTPUT_PARAMS : bepi_xyz_hee
+#
+# --------------------
+# DERIVED PARAMETERS :
+# --------------------
+#
+# PARAMETER_ID : bepi_xyz_hee
+# PARAMETER_NAME : bepi_xyz_hee
+# PARAMETER_SHORT_NAME : xyz_hee
+# PARAMETER_UNITS : AU
+# PARAMETER_PROCESS_INFO : Derived parameter from expression '$bepi_cruise_all_HEE/ASTRONOMICAL_UNIT'
+# PARAMETER_PROCESS_DESC : $bepi_cruise_all_HEE/ASTRONOMICAL_UNIT
+# PARAMETER_LINKED_PARAMS : bepi_cruise_all_HEE
+#
+#
+# -----------------
+# BASE PARAMETERS :
+# -----------------
+#
+# MISSION_ID : NONE
+#
+#   INSTRUMENT_ID : NONE
+#
+#     DATASET_ID : bepi:cruise:all
+#     DATASET_NAME : bepi:cruise:all
+#     DATASET_SOURCE : CDPP/DDServer
+#     DATASET_GLOBAL_START : 2018-10-21T00:00:00.000
+#     DATASET_GLOBAL_STOP : 2025-11-01T22:00:00.000
+#     DATASET_MIN_SAMPLING : 3600
+#     DATASET_MAX_SAMPLING : 3600
+#
+#       PARAMETER_ID : bepi_cruise_all_HEE
+#       PARAMETER_NAME : bepi_cruise_all_HEE
+#       PARAMETER_SHORT_NAME : bepi_cruise_all_HEE
+#       PARAMETER_UNITS : unspecified
+#       PARAMETER_TENSOR_ORDER : 0
+#       PARAMETER_FILL_VALUE : nan
+#
+#
+# ---------------
+# INTERVAL INFO :
+# ---------------
+# INTERVAL_START : 2019-11-08T00:00:00.000
+# INTERVAL_STOP : 2019-11-08T00:10:00.000
+#
+# ------
+# DATA :
+# ------
+# DATA_COLUMNS : SECS FROM 1970-01-01, bepi_xyz_hee[0], bepi_xyz_hee[1], bepi_xyz_hee[2]
+#
+ 1.573171200001e+09     9.421308279928e-01     -3.942555302040e-01     4.233058199379e-04

--- a/tests/resources/derived_param2.txt
+++ b/tests/resources/derived_param2.txt
@@ -1,0 +1,128 @@
+# -----------
+# AMDA INFO :
+# -----------
+# AMDA_ABOUT : Created by AMDA
+# AMDA_VERSION : 3.6.5
+# AMDA_ACKNOWLEDGEMENT : CDPP/AMDA Team
+#
+# --------------
+# REQUEST INFO :
+# --------------
+# REQUEST_STRUCTURE : all-in-one-file-refparam
+# REQUEST_TIME_FORMAT : Seconds from 1970, milliseconds
+# REQUEST_OUTPUT_PARAMS : mms1_fast_jgse
+#
+# --------------------
+# DERIVED PARAMETERS :
+# --------------------
+#
+# PARAMETER_ID : sampling_under_refparam_6474261044550000668
+# PARAMETER_NAME : mms1_dis_vgse
+# PARAMETER_SHORT_NAME : v_gse
+# PARAMETER_UNITS : km/s
+# PARAMETER_PROCESS_INFO : Resampling of 'mms1_fpi_dismoms_mms1_dis_bulkv_gse_fast' under times list of 'mms1_fpi_desmoms_mms1_des_numberdensity_fast'
+# PARAMETER_LINKED_PARAMS : mms1_fpi_dismoms_mms1_dis_bulkv_gse_fast
+#
+#
+# PARAMETER_ID : sampling_under_refparam_4907928269817716892
+# PARAMETER_NAME : mms1_dis_ni
+# PARAMETER_SHORT_NAME : density
+# PARAMETER_UNITS : cm^-3
+# PARAMETER_PROCESS_INFO : Resampling of 'mms1_fpi_dismoms_mms1_dis_numberdensity_fast' under times list of 'mms1_fpi_desmoms_mms1_des_numberdensity_fast'
+# PARAMETER_LINKED_PARAMS : mms1_fpi_dismoms_mms1_dis_numberdensity_fast
+#
+#
+# PARAMETER_ID : sampling_under_refparam_3838272296942193163
+# PARAMETER_NAME : mms1_des_ne
+# PARAMETER_SHORT_NAME : density
+# PARAMETER_UNITS : cm^-3
+# PARAMETER_PROCESS_INFO : Resampling of 'mms1_fpi_desmoms_mms1_des_numberdensity_fast' under times list of 'mms1_fpi_desmoms_mms1_des_numberdensity_fast'
+# PARAMETER_LINKED_PARAMS : mms1_fpi_desmoms_mms1_des_numberdensity_fast
+#
+#
+# PARAMETER_ID : sampling_under_refparam_12014654095256152599
+# PARAMETER_NAME : mms1_des_vgse
+# PARAMETER_SHORT_NAME : v_gse
+# PARAMETER_UNITS : km/s
+# PARAMETER_PROCESS_INFO : Resampling of 'mms1_fpi_desmoms_mms1_des_bulkv_gse_fast' under times list of 'mms1_fpi_desmoms_mms1_des_numberdensity_fast'
+# PARAMETER_LINKED_PARAMS : mms1_fpi_desmoms_mms1_des_bulkv_gse_fast
+#
+#
+# PARAMETER_ID : mms1_fast_jgse
+# PARAMETER_NAME : mms1_fast_jgse
+# PARAMETER_SHORT_NAME : j_gse
+# PARAMETER_UNITS : A/m**2
+# PARAMETER_PROCESS_INFO : Derived parameter from expression '1.6e-10*(#sampling_under_refparam($mms1_des_ne;mms1_des_ne)+#sampling_under_refparam($mms1_dis_ni;mms1_des_ne))*0.5*(#sampling_under_refparam($mms1_dis_vgse;mms1_des_ne)-#sampling_under_refparam($mms1_des_vgse;mms1_des_ne))'
+# PARAMETER_PROCESS_DESC : 1.6e-10*(#sampling_under_refparam($mms1_des_ne;mms1_des_ne)+#sampling_under_refparam($mms1_dis_ni;mms1_des_ne))*0.5*(#sampling_under_refparam($mms1_dis_vgse;mms1_des_ne)-#sampling_under_refparam($mms1_des_vgse;mms1_des_ne))
+# PARAMETER_LINKED_PARAMS : sampling_under_refparam_12014654095256152599,sampling_under_refparam_3838272296942193163,sampling_under_refparam_4907928269817716892,sampling_under_refparam_6474261044550000668
+#
+#
+# -----------------
+# BASE PARAMETERS :
+# -----------------
+#
+# MISSION_ID : NONE
+#
+#   INSTRUMENT_ID : NONE
+#
+#     DATASET_ID : mms1-fpi-dismoms
+#     DATASET_NAME : mms1:fpi:dismoms
+#     DATASET_SOURCE : CDPP/DDServer
+#     DATASET_GLOBAL_START : 2015-07-15T15:11:27.381
+#     DATASET_GLOBAL_STOP : 2023-04-01T10:45:11.388
+#     DATASET_MIN_SAMPLING : 4
+#     DATASET_MAX_SAMPLING : 4
+#
+#       PARAMETER_ID : mms1_dis_ni
+#       PARAMETER_NAME : mms1_dis_ni
+#       PARAMETER_SHORT_NAME : density
+#       PARAMETER_UNITS : cm^-3
+#       PARAMETER_TENSOR_ORDER : 0
+#       PARAMETER_FILL_VALUE : nan
+#
+#       PARAMETER_ID : mms1_dis_vgse
+#       PARAMETER_NAME : mms1_dis_vgse
+#       PARAMETER_SHORT_NAME : v_gse
+#       PARAMETER_COMPONENTS : vx,vy,vz
+#       PARAMETER_UNITS : km/s
+#       PARAMETER_COORDINATE_SYSTEM : GSE
+#       PARAMETER_TENSOR_ORDER : 0
+#       PARAMETER_FILL_VALUE : nan
+#
+#     DATASET_ID : mms1-fpi-desmoms
+#     DATASET_NAME : mms1:fpi:desmoms
+#     DATASET_SOURCE : CDPP/DDServer
+#     DATASET_GLOBAL_START : 2015-07-15T15:11:27.381
+#     DATASET_GLOBAL_STOP : 2023-04-01T10:45:11.388
+#     DATASET_MIN_SAMPLING : 4
+#     DATASET_MAX_SAMPLING : 4
+#
+#       PARAMETER_ID : mms1_des_ne
+#       PARAMETER_NAME : mms1_des_ne
+#       PARAMETER_SHORT_NAME : density
+#       PARAMETER_UNITS : cm^-3
+#       PARAMETER_TENSOR_ORDER : 0
+#       PARAMETER_FILL_VALUE : nan
+#
+#       PARAMETER_ID : mms1_des_vgse
+#       PARAMETER_NAME : mms1_des_vgse
+#       PARAMETER_SHORT_NAME : v_gse
+#       PARAMETER_COMPONENTS : vx,vy,vz
+#       PARAMETER_UNITS : km/s
+#       PARAMETER_COORDINATE_SYSTEM : GSE
+#       PARAMETER_TENSOR_ORDER : 0
+#       PARAMETER_FILL_VALUE : nan
+#
+#
+# ---------------
+# INTERVAL INFO :
+# ---------------
+# INTERVAL_START : 2019-11-08T00:00:00.000
+# INTERVAL_STOP : 2019-11-08T00:10:00.000
+#
+# ------
+# DATA :
+# ------
+# DATA_COLUMNS : SECS FROM 1970-01-01, mms1_fast_jgse[0], mms1_fast_jgse[1], mms1_fast_jgse[2]
+#
+ 1.573171200119e+09  1.77979e-08 -4.50421e-08  1.34063e-08

--- a/tests/test_amda.py
+++ b/tests/test_amda.py
@@ -192,7 +192,16 @@ class AMDAModule(unittest.TestCase):
         self.assertEqual(var.values.shape[0], len(var.time))
         self.assertEqual(var.values.shape[1], len(var.columns))
         self.assertGreater(len(var.time), 0)
-        self.assertTrue('MISSION_ID' in var.meta)
+        self.assertIn('MISSION_ID', var.meta)
+        self.assertEqual(var.unit, '1/cm#u2#d/sec/ster/keV')
+
+    def test_loads_csv_derived_param(self):
+        var = load_csv(
+            os.path.normpath(f'{os.path.dirname(os.path.abspath(__file__))}/resources/derived_param.txt'))
+        self.assertEqual(var.values.shape[0], len(var.time))
+        self.assertEqual(var.values.shape[1], len(var.columns))
+        self.assertGreater(len(var.time), 0)
+        self.assertEqual(var.unit, 'AU')
 
     def test_load_obs_datatree(self):
         with open(


### PR DESCRIPTION
Since CSV is still the default format for ADMA with speasy, I felt like we should fix this issue.