### PR TITLE
Handles cases where labels are missing in CDAWeb generated files

### DIFF
--- a/speasy/core/cdf/__init__.py
+++ b/speasy/core/cdf/__init__.py
@@ -1,4 +1,5 @@
 import pyistp
+
 from ...products import SpeasyVariable, VariableAxis, VariableTimeAxis, DataContainer
 
 
@@ -26,6 +27,16 @@ def _make_axis(axis, time_axis_name):
                         is_time_dependent=is_time_dependent)
 
 
+def _build_labels(variable: pyistp.loader.DataVariable):
+    if len(variable.values.shape) != 2:
+        return variable.labels
+    if type(variable.labels) is list and len(variable.labels) == variable.values.shape[1]:
+        return variable.labels
+    if type(variable.labels) is list and len(variable.labels) == 1:
+        return [f"{variable.labels[0]}[{i}]" for i in range(variable.values.shape[1])]
+    return [f"component_{i}" for i in range(variable.values.shape[1])]
+
+
 def load_variable(variable="", file=None, buffer=None) -> SpeasyVariable or None:
     istp = pyistp.load(file=file, buffer=buffer)
     if istp:
@@ -46,5 +57,5 @@ def load_variable(variable="", file=None, buffer=None) -> SpeasyVariable or None
                 values=DataContainer(values=var.values.copy(), meta=_fix_attributes_types(var.attributes),
                                      name=var.name,
                                      is_time_dependent=True),
-                columns=var.labels)
+                columns=_build_labels(var))
     return None

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -5,9 +5,8 @@ from datetime import datetime, timedelta, timezone
 from multiprocessing import dummy
 
 import numpy as np
-from ddt import data, ddt
-
 import speasy as spz
+from ddt import data, ddt
 
 
 @ddt
@@ -40,6 +39,12 @@ class SimpleRequest(unittest.TestCase):
             "variable": "mms1_scm_acb_gse_scb_brst_l2",
             "start_time": datetime(2020, 1, 1, tzinfo=timezone.utc),
             "stop_time": datetime(2020, 1, 1, 2, tzinfo=timezone.utc)
+        },
+        {
+            "dataset": "ERG_ORB_L3",
+            "variable": "pos_eq_op",
+            "start_time": datetime(2018, 1, 1, tzinfo=timezone.utc),
+            "stop_time": datetime(2018, 1, 1, 2, tzinfo=timezone.utc)
         }
     )
     def test_get_variable(self, kw):
@@ -49,6 +54,7 @@ class SimpleRequest(unittest.TestCase):
         result = spz.cda.get_variable(**kw, disable_proxy=True, disable_cache=False)
         self.assertIsNotNone(result)
         self.assertGreater(len(result), 0)
+        self.assertEqual(len(result.columns), result.values.shape[1])
 
     def test_get_simple_vector(self):
         logging.root.addHandler(logging.StreamHandler())


### PR DESCRIPTION
Products like ERG_ORBS_L3/pos_eq_op from CDAWeb miss LABEL_PTR_1 attribute, this PR will generate some depending on what's available.
This only applies to multi components time-series. 