### PR TITLE
Fixes non ISTP compliant files axis merging

### DIFF
--- a/speasy/core/cdf/__init__.py
+++ b/speasy/core/cdf/__init__.py
@@ -22,13 +22,17 @@ def _fix_attributes_types(attributes: dict):
     return cleaned
 
 
-def _make_axis(axis, time_axis_name):
+def _is_time_dependent(axis, time_axis_name):
+    if axis.attributes.get('DEPEND_TIME', '') == time_axis_name:
+        return True
     if axis.attributes.get('DEPEND_0', '') == time_axis_name:
-        is_time_dependent = True
-    else:
-        is_time_dependent = False
+        return True
+    return False
+
+
+def _make_axis(axis, time_axis_name):
     return VariableAxis(values=axis.values.copy(), meta=_fix_attributes_types(axis.attributes), name=axis.name,
-                        is_time_dependent=is_time_dependent)
+                        is_time_dependent=_is_time_dependent(axis, time_axis_name))
 
 
 def _build_labels(variable: pyistp.loader.DataVariable):

--- a/speasy/webservices/generic_archive/__init__.py
+++ b/speasy/webservices/generic_archive/__init__.py
@@ -11,9 +11,9 @@ from typing import Optional
 
 from speasy.config import SPEASY_CONFIG_DIR
 from speasy.config import archive as cfg
-from speasy.core import AnyDateTimeType
+from speasy.core import AnyDateTimeType, AllowedKwargs
 from speasy.core.cdf.inventory_extractor import make_dataset_index
-from speasy.core.dataprovider import DataProvider
+from speasy.core.dataprovider import DataProvider, GET_DATA_ALLOWED_KWARGS
 from speasy.core.direct_archive_downloader import get_product
 from speasy.core.inventory.indexes import SpeasyIndex, ParameterIndex
 from speasy.products.variable import SpeasyVariable
@@ -82,6 +82,7 @@ class GenericArchive(DataProvider):
         else:
             raise ValueError(f"Got unexpected type {type(product)}, expecting str or ParameterIndex")
 
+    @AllowedKwargs(GET_DATA_ALLOWED_KWARGS)
     def get_data(self, product: str or ParameterIndex, start_time: AnyDateTimeType, stop_time: AnyDateTimeType,
                  **kwargs) -> Optional[SpeasyVariable]:
         var = self._get_data(product=self._parameter_index(product), start_time=start_time, stop_time=stop_time)

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -97,6 +97,12 @@ class DirectArchiveDownloader(unittest.TestCase):
         v = spz.get_data(product, start, stop)
         self.assertIsNotNone(v)
 
+    def test_axes_merging_across_files(self):
+        v = spz.get_data(spz.inventories.tree.archive.cdpp.THEMIS.THA.L2.tha_esa.tha_peif_en_eflux, "2018-01-05",
+                         "2018-01-07")
+        self.assertIsNotNone(v)
+        self.assertEqual(len(v), len(v.axes[1]))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some files uses DEPEND_TIME instead of DEPEND_0 to point to time axis. This was supported by speasy for data variables but not for support variables.