### PR TITLE
Fix archive no files

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-* Space Physics WebServices Client version:
+* Speasy version:
 * Python version:
 * Operating System:
 

--- a/scripts/direct_archive_yaml_gen.ipynb
+++ b/scripts/direct_archive_yaml_gen.ipynb
@@ -4,7 +4,6 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": true,
     "ExecuteTime": {
      "end_time": "2023-07-05T09:03:01.397104357Z",
      "start_time": "2023-07-05T09:03:01.394156094Z"
@@ -18,6 +17,16 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2023-07-05T09:03:01.397594296Z",
+     "start_time": "2023-07-05T09:03:01.396060568Z"
+    },
+    "collapsed": false,
+    "jupyter": {
+     "outputs_hidden": false
+    }
+   },
    "outputs": [],
    "source": [
     "inventory = {}\n",
@@ -35,35 +44,91 @@
     "with open('../speasy/data/archive/themis_cdpp.yaml', 'w') as inv_f:\n",
     "    yaml.dump(inventory, inv_f)\n",
     "\n"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "ExecuteTime": {
-     "end_time": "2023-07-05T09:03:01.397594296Z",
-     "start_time": "2023-07-05T09:03:01.396060568Z"
-    }
-   }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "inventory = {}\n",
+    "\n",
+    "inventory['erg_lepe_l3_pa'] = {\n",
+    "            'url_pattern': 'https://cdaweb.gsfc.nasa.gov/pub/data/arase/lepe/l3/pa/{Y}/erg_lepe_l3_pa_{Y}{M:02d}{D:02d}_v\\\\d+_\\\\d+.cdf',\n",
+    "            'use_file_list': True,\n",
+    "            'master_cdf': \"https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_lepe_l3_pa_00000000_v01.cdf\",\n",
+    "            'inventory_path': 'cda/Arase_ERG/LEPE',\n",
+    "            'split_rule': \"regular\"\n",
+    "        }\n",
+    "\n",
+    "inventory['erg_pwe_hfa_l3_1min'] = {\n",
+    "            'url_pattern': 'https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v\\\\d+_\\\\d+.cdf',\n",
+    "            'use_file_list': True,\n",
+    "            'master_cdf': \"https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_pwe_hfa_l3_1min_00000000_v01.cdf\",\n",
+    "            'inventory_path': 'cda/Arase_ERG/PWE/HFA',\n",
+    "            'split_rule': \"regular\"\n",
+    "        }\n",
+    "\n",
+    "for spacecraft in range(1,5):\n",
+    "    for mode,MODE in (('fast','FAST'), ('brst','BURST')):\n",
+    "        inventory[f'mms{spacecraft}_fpi_{mode}_l2_des_moms'] = {\n",
+    "            'url_pattern': f'https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms{spacecraft}/fpi/{mode}/l2/des-moms/{{Y}}/{{M:02d}}/mms{spacecraft}_fpi_{mode}_l2_des-moms_{{Y}}{{M:02d}}\\\\d+_v\\\\d+.\\\\d+.\\\\d+.cdf',\n",
+    "            'use_file_list': True,\n",
+    "            'master_cdf': f\"https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms{spacecraft}_fpi_{mode}_l2_des-moms_00000000_v01.cdf\",\n",
+    "            'inventory_path': f'cda/MMS/MMS{spacecraft}/FPI/{MODE}/MOMS',\n",
+    "            'split_rule': \"random\",\n",
+    "            'split_frequency': \"monthly\",\n",
+    "            'fname_regex': f'mms{spacecraft}_fpi_{mode}_l2_des-moms_(?P<start>\\\\d+)_v(?P<version>[\\\\d\\\\.]+)\\\\.cdf'\n",
+    "        }\n",
+    "\n",
+    "    inventory[f'mms{spacecraft}_fgm_srvy_l2'] = {\n",
+    "        'url_pattern': f'https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms{spacecraft}/fgm/srvy/l2/{{Y}}/{{M:02d}}/mms{spacecraft}_fgm_srvy_l2_{{Y}}{{M:02d}}{{D:02d}}_v\\\\d+.\\\\d+.\\\\d+.cdf',\n",
+    "        'use_file_list': True,\n",
+    "        'master_cdf': f\"https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms{spacecraft}_fgm_srvy_l2_00000000_v01.cdf\",\n",
+    "        'inventory_path': f'cda/MMS/MMS{spacecraft}/FGM/SRVY',\n",
+    "        'split_rule': \"regular\"\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "with open('../speasy/data/archive/cda.yaml', 'w') as inv_f:\n",
+    "    yaml.dump(inventory, inv_f)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.12.0"
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/speasy/core/direct_archive_downloader/direct_archive_downloader.py
+++ b/speasy/core/direct_archive_downloader/direct_archive_downloader.py
@@ -20,16 +20,21 @@ from speasy.products.variable import merge
 
 
 @CacheCall(cache_retention=timedelta(hours=24), is_pure=True)
-def _read_cdf(url: str, variable: str) -> SpeasyVariable:
+def _read_cdf(url: Optional[str], variable: str) -> Optional[SpeasyVariable]:
+    if url is None:
+        return None
     return load_variable(file=url, variable=variable)
 
 
-def _build_url(url_pattern: str, date: datetime, use_file_list=False) -> str:
+def _build_url(url_pattern: str, date: datetime, use_file_list=False) -> Optional[str]:
     base_ulr = url_pattern.format(Y=date.year, M=date.month, D=date.day)
     if not use_file_list:
         return base_ulr
     folder_url, rx = base_ulr.rsplit('/', 1)
-    return '/'.join((folder_url, sorted(list_files(folder_url, re.compile(rx)))[-1]))
+    files = sorted(list_files(folder_url, re.compile(rx)))
+    if len(files):
+        return '/'.join((folder_url, files[-1]))
+    return None
 
 
 def spilt_range(split_frequency: str, start_time: AnyDateTimeType, stop_time: AnyDateTimeType):

--- a/speasy/data/archive/cda.yaml
+++ b/speasy/data/archive/cda.yaml
@@ -1,48 +1,100 @@
----
 erg_lepe_l3_pa:
-    url_pattern: "https://cdaweb.gsfc.nasa.gov/pub/data/arase/lepe/l3/pa/{Y}/erg_lepe_l3_pa_{Y}{M:02d}{D:02d}_v03_01.cdf"
-    master_cdf: "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_lepe_l3_pa_00000000_v01.cdf"
-    inventory_path: 'cda/Arase_ERG/LEPE'
-    split_rule: "regular"
+  inventory_path: cda/Arase_ERG/LEPE
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_lepe_l3_pa_00000000_v01.cdf
+  split_rule: regular
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/arase/lepe/l3/pa/{Y}/erg_lepe_l3_pa_{Y}{M:02d}{D:02d}_v\d+_\d+.cdf
+  use_file_list: true
 erg_pwe_hfa_l3_1min:
-    url_pattern: 'https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v\d+_\d+.cdf'
-    use_file_list: true
-    master_cdf: "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_pwe_hfa_l3_1min_00000000_v01.cdf"
-    inventory_path: 'cda/Arase_ERG/PWE/HFA'
-    split_rule: "regular"
-
+  inventory_path: cda/Arase_ERG/PWE/HFA
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_pwe_hfa_l3_1min_00000000_v01.cdf
+  split_rule: regular
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v\d+_\d+.cdf
+  use_file_list: true
+mms1_fgm_srvy_l2:
+  inventory_path: cda/MMS/MMS1/FGM/SRVY
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms1_fgm_srvy_l2_00000000_v01.cdf
+  split_rule: regular
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms1/fgm/srvy/l2/{Y}/{M:02d}/mms1_fgm_srvy_l2_{Y}{M:02d}{D:02d}_v\d+.\d+.\d+.cdf
+  use_file_list: true
 mms1_fpi_brst_l2_des_moms:
-    url_pattern: 'https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms1/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms1_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf'
-    use_file_list: true
-    master_cdf: "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms1_fpi_brst_l2_des-moms_00000000_v01.cdf"
-    inventory_path: 'cda/MMS/MMS1/FPI/BURST/MOMS'
-    split_rule: "random"
-    split_frequency: "monthly"
-    fname_regex: 'mms1_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf'
-
+  fname_regex: mms1_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS1/FPI/BURST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms1_fpi_brst_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms1/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms1_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms1_fpi_fast_l2_des_moms:
+  fname_regex: mms1_fpi_fast_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS1/FPI/FAST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms1_fpi_fast_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms1/fpi/fast/l2/des-moms/{Y}/{M:02d}/mms1_fpi_fast_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms2_fgm_srvy_l2:
+  inventory_path: cda/MMS/MMS2/FGM/SRVY
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms2_fgm_srvy_l2_00000000_v01.cdf
+  split_rule: regular
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms2/fgm/srvy/l2/{Y}/{M:02d}/mms2_fgm_srvy_l2_{Y}{M:02d}{D:02d}_v\d+.\d+.\d+.cdf
+  use_file_list: true
 mms2_fpi_brst_l2_des_moms:
-    url_pattern: 'https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms2/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms2_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf'
-    use_file_list: true
-    master_cdf: "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms2_fpi_brst_l2_des-moms_00000000_v01.cdf"
-    inventory_path: 'cda/MMS/MMS2/FPI/BURST/MOMS'
-    split_rule: "random"
-    split_frequency: "monthly"
-    fname_regex: 'mms2_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf'
-
+  fname_regex: mms2_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS2/FPI/BURST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms2_fpi_brst_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms2/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms2_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms2_fpi_fast_l2_des_moms:
+  fname_regex: mms2_fpi_fast_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS2/FPI/FAST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms2_fpi_fast_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms2/fpi/fast/l2/des-moms/{Y}/{M:02d}/mms2_fpi_fast_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms3_fgm_srvy_l2:
+  inventory_path: cda/MMS/MMS3/FGM/SRVY
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms3_fgm_srvy_l2_00000000_v01.cdf
+  split_rule: regular
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms3/fgm/srvy/l2/{Y}/{M:02d}/mms3_fgm_srvy_l2_{Y}{M:02d}{D:02d}_v\d+.\d+.\d+.cdf
+  use_file_list: true
 mms3_fpi_brst_l2_des_moms:
-    url_pattern: 'https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms3/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms3_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf'
-    use_file_list: true
-    master_cdf: "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms3_fpi_brst_l2_des-moms_00000000_v01.cdf"
-    inventory_path: 'cda/MMS/MMS3/FPI/BURST/MOMS'
-    split_rule: "random"
-    split_frequency: "monthly"
-    fname_regex: 'mms3_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf'
-
+  fname_regex: mms3_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS3/FPI/BURST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms3_fpi_brst_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms3/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms3_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms3_fpi_fast_l2_des_moms:
+  fname_regex: mms3_fpi_fast_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS3/FPI/FAST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms3_fpi_fast_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms3/fpi/fast/l2/des-moms/{Y}/{M:02d}/mms3_fpi_fast_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms4_fgm_srvy_l2:
+  inventory_path: cda/MMS/MMS4/FGM/SRVY
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms4_fgm_srvy_l2_00000000_v01.cdf
+  split_rule: regular
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms4/fgm/srvy/l2/{Y}/{M:02d}/mms4_fgm_srvy_l2_{Y}{M:02d}{D:02d}_v\d+.\d+.\d+.cdf
+  use_file_list: true
 mms4_fpi_brst_l2_des_moms:
-    url_pattern: 'https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms4/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms4_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf'
-    use_file_list: true
-    master_cdf: "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms4_fpi_brst_l2_des-moms_00000000_v01.cdf"
-    inventory_path: 'cda/MMS/MMS4/FPI/BURST/MOMS'
-    split_rule: "random"
-    split_frequency: "monthly"
-    fname_regex: 'mms4_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf'
+  fname_regex: mms4_fpi_brst_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS4/FPI/BURST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms4_fpi_brst_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms4/fpi/brst/l2/des-moms/{Y}/{M:02d}/mms4_fpi_brst_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true
+mms4_fpi_fast_l2_des_moms:
+  fname_regex: mms4_fpi_fast_l2_des-moms_(?P<start>\d+)_v(?P<version>[\d\.]+)\.cdf
+  inventory_path: cda/MMS/MMS4/FPI/FAST/MOMS
+  master_cdf: https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/mms4_fpi_fast_l2_des-moms_00000000_v01.cdf
+  split_frequency: monthly
+  split_rule: random
+  url_pattern: https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms4/fpi/fast/l2/des-moms/{Y}/{M:02d}/mms4_fpi_fast_l2_des-moms_{Y}{M:02d}\d+_v\d+.\d+.\d+.cdf
+  use_file_list: true

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -97,9 +97,36 @@ class DirectArchiveDownloader(unittest.TestCase):
         v = spz.get_data(product, start, stop)
         self.assertIsNotNone(v)
 
-    def test_get_data_with_no_file(self):
-        v = spz.get_data(spz.inventories.tree.archive.cdpp.THEMIS.THA.L2.tha_scm.tha_scf_gse, "2018-03-10",
-                         "2018-03-11")
+    @data(
+        ("archive/cdpp/THEMIS/THA/L2/tha_scm/tha_scf_gse",
+         "2018-03-10",
+         "2018-03-11"),
+        ("archive/cda/MMS/MMS1/FGM/SRVY/mms1_fgm_srvy_l2/mms1_fgm_b_bcs_srvy_l2",
+         "2019-08-19",
+         "2019-08-25"),
+    )
+    @unpack
+    def test_get_data_with_no_file(self, product, start, stop):
+        v = spz.get_data(product, start, stop)
+        self.assertIsNone(v)
+
+    @data(
+        ("archive/cda/MMS/MMS1/FGM/SRVY/mms1_fgm_srvy_l2/mms1_fgm_b_bcs_srvy_l2",
+         "2010-08-19",
+         "2010-08-25"),
+        ("archive/cdpp/THEMIS/THA/L2/tha_scm/tha_scf_gse",
+         "2030-03-10",
+         "2030-03-11"),
+        ("archive/cda/MMS/MMS1/FPI/BURST/MOMS/mms1_fpi_brst_l2_des_moms/mms1_des_temppara_brst",
+         "2006-02-28",
+         "2006-03-02"),
+        ("archive/cda/MMS/MMS1/FPI/FAST/MOMS/mms1_fpi_fast_l2_des_moms/mms1_des_energyspectr_omni_fast",
+         "2010-01-30T10",
+         "2010-02-01T12"),
+    )
+    @unpack
+    def test_get_data_outside_of_range(self, product, start, stop):
+        v = spz.get_data(product, start, stop)
         self.assertIsNone(v)
 
     def test_axes_merging_across_files(self):

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -97,6 +97,11 @@ class DirectArchiveDownloader(unittest.TestCase):
         v = spz.get_data(product, start, stop)
         self.assertIsNotNone(v)
 
+    def test_get_data_with_no_file(self):
+        v = spz.get_data(spz.inventories.tree.archive.cdpp.THEMIS.THA.L2.tha_scm.tha_scf_gse, "2018-03-10",
+                         "2018-03-11")
+        self.assertIsNone(v)
+
     def test_axes_merging_across_files(self):
         v = spz.get_data(spz.inventories.tree.archive.cdpp.THEMIS.THA.L2.tha_esa.tha_peif_en_eflux, "2018-01-05",
                          "2018-01-07")


### PR DESCRIPTION
There is not always a file for a given time interval on remote servers, so speasy should handle this and just return None 
instead of crashing.
This PR also adds few more products from CDAWeb archive access for MMS as examples and useful to test this PR.