### PR TITLE
If last cache fragment is None then don't slice it

### DIFF
--- a/docs/user/amda/amda.rst
+++ b/docs/user/amda/amda.rst
@@ -43,7 +43,7 @@ Let's start with a simple example, we want to download the first parameter avail
     <ParameterIndex: He flux>
     >>> first_param=amda.get_parameter(first_param_index, "2018-01-01", "2018-01-02T01")
     >>> first_param.columns
-    ['He flux']
+    ['He flux[0]', 'He flux[1]']
     >>> len(first_param.time)
     288
 

--- a/speasy/core/__init__.py
+++ b/speasy/core/__init__.py
@@ -169,12 +169,12 @@ def make_utc_datetime(input_dt: AnyDateTimeType) -> datetime:
     datetime.datetime(2020, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
     """
     if type(input_dt) in (np.float64, float):
-        return datetime.utcfromtimestamp(input_dt)
+        return datetime.fromtimestamp(input_dt, tz=timezone.utc)
     if type(input_dt) is str:
         input_dt = parse(input_dt)
     if type(input_dt) is np.datetime64:
         if input_dt.dtype == np.dtype('datetime64[ns]'):
-            return datetime.utcfromtimestamp(input_dt.astype(np.int64) * 1e-9)
+            return datetime.fromtimestamp(input_dt.astype(np.int64) * 1e-9, tz=timezone.utc)
 
     return datetime(input_dt.year, input_dt.month, input_dt.day, input_dt.hour, input_dt.minute, input_dt.second,
                     input_dt.microsecond, tzinfo=timezone.utc)

--- a/speasy/core/cache/_providers_caches.py
+++ b/speasy/core/cache/_providers_caches.py
@@ -275,7 +275,8 @@ class UnversionedProviderCache(object):
                 if len(data_chunks) == 1:
                     return data_chunks[0][dt_range.start_time:dt_range.stop_time].copy()
                 data_chunks[0] = data_chunks[0][dt_range.start_time:]
-                data_chunks[-1] = data_chunks[-1][:dt_range.stop_time]
+                if data_chunks[-1] is not None:
+                    data_chunks[-1] = data_chunks[-1][:dt_range.stop_time]
                 return merge_variables(data_chunks)[dt_range.start_time:dt_range.stop_time]
             return None
 

--- a/tests/test_amda_parameter.py
+++ b/tests/test_amda_parameter.py
@@ -71,7 +71,8 @@ class ParameterRequests(unittest.TestCase):
         dataset = None
         for dataset in spz.inventories.flat_inventories.amda.datasets.values():
             if hasattr(dataset, 'timeRestriction'):
-                break
+                if (make_utc_datetime(dataset.timeRestriction) + timedelta(minutes=1))< make_utc_datetime(dataset.stop_date):
+                    break
         if dataset is not None:
             from speasy.webservices.amda.exceptions import MissingCredentials
             from speasy.core import make_utc_datetime

--- a/tests/test_amda_parameter.py
+++ b/tests/test_amda_parameter.py
@@ -66,16 +66,17 @@ class ParameterRequests(unittest.TestCase):
 
     def test_restricted_time_range(self):
         from speasy.webservices.amda._impl import credential_are_valid
+        from speasy.core import make_utc_datetime
+
         if credential_are_valid():
             self.skipTest("Should only run when credentials are not valid")
         dataset = None
         for dataset in spz.inventories.flat_inventories.amda.datasets.values():
             if hasattr(dataset, 'timeRestriction'):
-                if (make_utc_datetime(dataset.timeRestriction) + timedelta(minutes=1))< make_utc_datetime(dataset.stop_date):
+                if make_utc_datetime(dataset.timeRestriction)< make_utc_datetime(dataset.stop_date):
                     break
         if dataset is not None:
             from speasy.webservices.amda.exceptions import MissingCredentials
-            from speasy.core import make_utc_datetime
             with self.assertRaises(MissingCredentials):
                 spz.amda.get_dataset(dataset, make_utc_datetime(dataset.timeRestriction),
                                      make_utc_datetime(dataset.timeRestriction) + timedelta(minutes=1))

--- a/tests/test_http_module.py
+++ b/tests/test_http_module.py
@@ -22,7 +22,7 @@ class HttpTests(unittest.TestCase):
 
 
     @data(
-        ("http://somewhere.com", False),
+        ("http://somewhere-that-does-not-exist-404.com", False),
         ("https://hephaistos.lpp.polytechnique.fr", True),
         ("https://sciqlop.lpp.polytechnique.fr/", False),
     )


### PR DESCRIPTION
This was a long standing bug I mainly see on our proxy but didn't understand until now. 
In the maybe outdated section I can still get a None entry value.