### PR TITLE
Using SciQLop proxy for CDA direct files access makes no sense

### DIFF
--- a/docs/user/csa/csa.rst
+++ b/docs/user/csa/csa.rst
@@ -20,7 +20,7 @@ Once you have found your product, then simply ask CSA module to get data for the
     >>> c3_fgm_spin = spz.csa.get_data(spz.inventories.data_tree.csa.Cluster.Cluster_3.FGM3.C3_CP_FGM_SPIN.B_vec_xyz_gse__C3_CP_FGM_SPIN, "2018-01-01", "2018-01-01T01")
     >>> c3_fgm_spin.columns
     ['Bx', 'By', 'Bz']
-    >>> c3_fgm_spin.values
+    >>> c3_fgm_spin.values.astype("float32")
     array([[  4.603,  13.444, -16.832],
            [  4.684,  12.852, -16.708],
            [  2.86 ,  12.794, -17.362],

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -158,7 +158,7 @@ core = ConfigSection("CORE",
                                          "description": """A comma separated list of providers you want to disable.
 The main benefit of disabling providers is to speedup speasy loading.""",
                                          "type_ctor": lambda x: set(x.split(','))},
-                     http_rewrite_rules={"default": {},
+                     http_rewrite_rules={"default": {"https://cdaweb.gsfc.nasa.gov/pub/":"http://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/"},
                                          "description": """A dictionary of rules to rewrite URLs before sending requests.
 The keys are the URL to match and the values are the replacement URL.
 Example: {"http://example.com": "http://localhost:8000"}""",

--- a/speasy/webservices/cda/__init__.py
+++ b/speasy/webservices/cda/__init__.py
@@ -191,7 +191,6 @@ class CDA_Webservice(DataProvider):
         return self._dl_variable(start_time=start_time, stop_time=stop_time, dataset=dataset,
                                  variable=variable, if_newer_than=if_newer_than, extra_http_headers=extra_http_headers)
 
-    @Proxyfiable(GetProduct, get_parameter_args_archive)
     def _get_data_with_direct_archive(self, product, start_time: datetime, stop_time: datetime, mode_is_best: bool,
                                       if_newer_than: datetime or None = None,
                                       extra_http_headers: Dict or None = None) -> Optional[SpeasyVariable]:


### PR DESCRIPTION
Using proxy here would mean adding another cache level, just use our cdaweb cached reverse proxy instead.