### PR TITLE
Reduces axes count according to numpy reduction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,5 @@ homepage = "https://github.com/SciQLop/speasy"
 [project.optional-dependencies]
 zstd = ["pyzstd"]
 
+[tool.ruff.lint]
+select = ["NPY201"]


### PR DESCRIPTION
Some Numpy functions like sum, mean,... reduces the number of dimensions so resulting SpeasyVariables must adjust axes accordingly.