### PR TITLE
Allows to pass a custom file reader to the archive module

### DIFF
--- a/speasy/core/direct_archive_downloader/direct_archive_downloader.py
+++ b/speasy/core/direct_archive_downloader/direct_archive_downloader.py
@@ -18,7 +18,9 @@ from speasy.core.span_utils import intersects
 from speasy.products import SpeasyVariable
 from speasy.products.variable import merge
 
-FileLoaderCallable = Callable[[Optional[str], str, ...], Optional[SpeasyVariable]]
+# Change to this when we drop Python 3.8
+# FileLoaderCallable = Callable[[Optional[str], str, ...], Optional[SpeasyVariable]]
+FileLoaderCallable = Callable[..., Optional[SpeasyVariable]]
 
 
 def apply_date_format(txt: str, date: datetime) -> str:

--- a/speasy/products/catalog.py
+++ b/speasy/products/catalog.py
@@ -23,9 +23,6 @@ class Event(DateTimeRange):
     meta : dict
             Additional event data
 
-    Methods
-    -------
-
     Notes
     -----
     This class support the same operations as a speasy.common.datetime_range.DateTimeRange.

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -5,7 +5,8 @@ from ddt import ddt, data, unpack
 import speasy as spz
 from speasy.core import make_utc_datetime
 from speasy.core.cdf.inventory_extractor import extract_parameters
-from speasy.core.direct_archive_downloader.direct_archive_downloader import get_product, spilt_range, _read_cdf
+from speasy.core.direct_archive_downloader import get_product
+from speasy.core.direct_archive_downloader.direct_archive_downloader import spilt_range, _read_cdf
 
 
 def _custom_cdf_loader(url, variable, *args, **kwargs):


### PR DESCRIPTION
This can be used as a workaround for non ISTP compliant CDFs or others unsupported formats.