### PR TITLE
Adds request deduplication for cached remote file access

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,8 @@
 [run]
 branch = True
+concurrency = multiprocessing
+parallel = true
+sigterm = true
 
 omit =
     tests/*

--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -52,7 +52,7 @@ jobs:
         sudo apt update && sudo apt install -y texlive pandoc
         pip install pytest pytest-cov sphinx pandoc
         pip install -r docs/requirements.txt
-        pytest --cov=./ --cov-report=xml
+        pytest --cov=./ -cov-config=.coveragerc --cov-report=xml
         make doctest
     - name: Check that release process is not broken
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         sudo apt update && sudo apt install -y texlive pandoc
         pip install pytest pytest-cov sphinx pandoc
         pip install -r docs/requirements.txt
-        pytest --cov=./ --cov-report=xml
+        pytest --cov=./ -cov-config=.coveragerc --cov-report=xml
         make doctest
     - name: Check that release process is not broken
       if: matrix.python-version == '3.8' && matrix.os == 'ubuntu-latest'

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,6 @@
 pandas
 pytest-runner
+pytest-cov
 appdirs
 diskcache
 requests

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -1,5 +1,5 @@
 import unittest
-
+from multiprocessing import Pool
 from ddt import ddt, data, unpack
 
 import speasy as spz


### PR DESCRIPTION
When downloading remote files a temporary cache entry is created to notify any concurrent request on the same file.
This ensures we only download once any file when requesting it from several concurrent processes or threads.
Another improvement it brings, is download sequence randomization when the archive module need to merge several files, since with deduplication any concurrent process will sleep/wait until the data is there, reducing chances of collisions increases chances that all processes are requesting a different file at the same time. 
It improves a lot the use case when the user want to plot in SciQLop several products from the same dataset across several days or files. (each file is downloaded once and, its likely that thanks to randomization not all threads will request the same file at the same time)
