### PR TITLE
Preserves SpeasyVariable values dtype across dictionary serialization

### DIFF
--- a/speasy/core/cache/cache.py
+++ b/speasy/core/cache/cache.py
@@ -5,7 +5,7 @@ from .version import str_to_version, version_to_str, Version
 from speasy.config import cache as cache_cfg
 from contextlib import ExitStack
 
-cache_version = str_to_version("2.0")
+cache_version = str_to_version("3.0")
 
 
 class CacheItem:

--- a/speasy/core/data_containers.py
+++ b/speasy/core/data_containers.py
@@ -80,19 +80,25 @@ class DataContainer(object):
             "values": self.__values.tolist() if array_to_list else self.__values.copy(),
             "meta": self.__meta.copy(),
             "name": self.__name,
-            "is_time_dependent": self.is_time_dependent
+            "is_time_dependent": self.is_time_dependent,
+            "values_type": str(self.__values.dtype)
         }
 
     @staticmethod
     def from_dictionary(dictionary: Dict[str, str or Dict[str, str] or List], dtype=np.float64) -> "DataContainer":
         try:
-            return DataContainer(values=np.array(dictionary["values"], dtype=dtype), meta=dictionary["meta"],
-                                 name=dictionary["name"],
-                                 is_time_dependent=dictionary["is_time_dependent"])
+            return DataContainer(
+                values=np.array(dictionary["values"], dtype=dictionary.get("values_type", dtype)),
+                meta=dictionary["meta"],
+                name=dictionary["name"],
+                is_time_dependent=dictionary["is_time_dependent"]
+            )
         except ValueError:
-            return DataContainer(values=np.array(dictionary["values"]), meta=dictionary["meta"],
-                                 name=dictionary["name"],
-                                 is_time_dependent=dictionary["is_time_dependent"])
+            return DataContainer(
+                values=np.array(dictionary["values"]), meta=dictionary["meta"],
+                name=dictionary["name"],
+                is_time_dependent=dictionary["is_time_dependent"]
+            )
 
     @staticmethod
     def reserve_like(other: 'DataContainer', length: int = 0) -> 'DataContainer':

--- a/speasy/core/proxy/__init__.py
+++ b/speasy/core/proxy/__init__.py
@@ -18,7 +18,7 @@ from ..cache import CacheCall
 
 log = logging.getLogger(__name__)
 PROXY_ALLOWED_KWARGS = ['disable_proxy']
-MINIMUM_REQUIRED_PROXY_VERSION = Version("0.10.0")
+MINIMUM_REQUIRED_PROXY_VERSION = Version("0.11.0")
 _CURRENT_PROXY_SERVER_VERSION = None
 
 if proxy_cfg.url() == "" or proxy_cfg.enabled() == False:

--- a/tests/test_speasy_variable.py
+++ b/tests/test_speasy_variable.py
@@ -22,9 +22,11 @@ def epoch_to_datetime64_s(epoch):
     return np.datetime64(int(epoch * 1e9), 'ns')
 
 
-def make_simple_var(start: float = 0., stop: float = 0., step: float = 1., coef: float = 1., meta=None):
+def make_simple_var(start: float = 0., stop: float = 0., step: float = 1., coef: float = 1., meta=None,
+                    dtype=np.float64):
     time = np.arange(start, stop, step)
     values = time * coef
+    values = values.astype(dtype)
     return SpeasyVariable(axes=[VariableTimeAxis(values=epoch_to_datetime64(time))],
                           values=DataContainer(values=values, is_time_dependent=True, meta=meta), columns=["Values"])
 
@@ -251,6 +253,13 @@ class ASpeasyVariable(unittest.TestCase):
         var3 = from_dictionary(to_dictionary(var1, array_to_list=True))
         self.assertEqual(var1, var2)
         self.assertEqual(var1, var3)
+
+    def test_from_dict_preserves_dtype(self):
+        for dtype in (np.float32, np.float64, np.int32, np.int64):
+            var = make_simple_var(1., 10., 1., 10., dtype=dtype)
+            var2 = from_dictionary(to_dictionary(var))
+            self.assertEqual(var.values.dtype, dtype)
+            self.assertEqual(var.values.dtype, var2.values.dtype)
 
     def test_from_dataframe(self):
         var1 = make_simple_var(1., 10., 1., 10.)


### PR DESCRIPTION
To avoid any weirdness with cache and proxy, I increased the cache model version which triggers a cache flush and minimum proxy version.


closes #139.

