### PR TITLE
Requirements order matter, Astropy has to be before Numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
+astropy
 pandas
 appdirs
 diskcache
 requests
 urllib3>=1.26.0
 packaging
-numpy
 python_dateutil
-astropy
 pyistp>=0.5.0
 astroquery
 tqdm
 matplotlib
 PyYAML
 scipy
+numpy

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+astropy
 pandas
 pytest-runner
 pytest-cov
@@ -6,9 +7,7 @@ diskcache
 requests
 urllib3>=1.26.0
 packaging
-numpy
 python_dateutil
-astropy
 ddt
 pytest
 pytest-cov
@@ -19,3 +18,4 @@ matplotlib
 scipy
 PyYAML
 pyzstd
+numpy


### PR DESCRIPTION
If Numpy is before then Numpy is pined to the latest available version and pip try to find a compatible Astropy version (good luck...)