### PR TITLE
Introduce a new inventory JSON/dict format that preserves more primitive types

### DIFF
--- a/speasy/core/impex/__init__.py
+++ b/speasy/core/impex/__init__.py
@@ -914,8 +914,7 @@ class ImpexProvider(DataProvider):
         if len(variables) == 0:
             return None
         elif len(variables) == 1:
-            result = list(variables.values())[0].copy()
-            return result
+            return list(variables.values())[0]
 
         axes = []
         columns = []

--- a/speasy/core/proxy/__init__.py
+++ b/speasy/core/proxy/__init__.py
@@ -18,7 +18,7 @@ from ..cache import CacheCall
 
 log = logging.getLogger(__name__)
 PROXY_ALLOWED_KWARGS = ['disable_proxy']
-MINIMUM_REQUIRED_PROXY_VERSION = Version("0.11.0")
+MINIMUM_REQUIRED_PROXY_VERSION = Version("0.12.0")
 _CURRENT_PROXY_SERVER_VERSION = None
 
 if proxy_cfg.url() == "" or proxy_cfg.enabled() == False:
@@ -113,13 +113,14 @@ class GetInventory:
         kwargs['provider'] = provider
         kwargs['format'] = 'python_dict'
         kwargs['zstd_compression'] = zstd_compression
+        kwargs['version'] = 2
         headers = {}
         if saved_inventory is not None:
             headers["If-Modified-Since"] = parser.parse(saved_inventory.build_date).ctime()
         resp = http.get(f"{url}/get_inventory", params=kwargs, headers=headers)
         log.debug(f"Asking {provider} inventory from proxy {resp.url}, {resp.headers}")
         if resp.status_code == 200:
-            inventory = inventory_from_dict(pickle.loads(decompress(resp.bytes)))
+            inventory = inventory_from_dict(pickle.loads(decompress(resp.bytes)), version=2)
             index.set("proxy_inventories", provider, inventory)
             index.set("proxy_inventories_save_date", provider, datetime.utcnow())
             return inventory

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -1,0 +1,53 @@
+import unittest
+from ddt import ddt, data, unpack
+
+import speasy as spz
+from speasy.core.inventory.indexes import from_dict, to_dict, SpeasyIndex
+from speasy.core.dataprovider import DataProvider
+
+
+def compare_inventories(inventory1: SpeasyIndex, inventory2: SpeasyIndex):
+    if inventory1.spz_name() != inventory2.spz_name():
+        print(f"Name mismatch: {inventory1.spz_name()} != {inventory2.spz_name()}")
+        return False
+    for key in inventory1.__dict__.keys():
+        if key not in inventory2.__dict__:
+            print(f"Key missing: {key}")
+            return False
+        value1 = inventory1.__dict__[key]
+        value2 = inventory2.__dict__[key]
+        if isinstance(value1, SpeasyIndex) and isinstance(value2, SpeasyIndex):
+            if not compare_inventories(value1, value2):
+                return False
+        elif value1 != value2:
+            print(f"Value mismatch: {value1} != {value2}")
+            return False
+    return True
+
+
+@ddt
+class FromDictAndToDictPreserveInventory(unittest.TestCase):
+
+    def assertInventoryEqual(self, inventory1: SpeasyIndex, inventory2: SpeasyIndex):
+        if inventory1.spz_name() != inventory2.spz_name():
+            self.fail(f"Name mismatch: {inventory1.spz_name()} != {inventory2.spz_name()}")
+        for key in inventory1.__dict__.keys():
+            if key not in inventory2.__dict__:
+                self.fail(f"Key missing: {key}")
+            value1 = inventory1.__dict__[key]
+            value2 = inventory2.__dict__[key]
+            if isinstance(value1, SpeasyIndex) and isinstance(value2, SpeasyIndex):
+                self.assertInventoryEqual(value1, value2)
+            elif value1 != value2:
+                self.fail(f"Value mismatch: {value1}({type(value1)}) != {value2}({type(value2)}) for key {key}")
+
+    @data(
+        (spz.amda,),
+        (spz.cda,),
+        (spz.ssc,),
+        (spz.csa,),
+    )
+    @unpack
+    def test_from_dict_and_to_dict_preserve_inventory(self, provider: DataProvider):
+        inventory = provider._inventory(provider_name=provider.provider_name, disable_proxy=True)
+        self.assertInventoryEqual(inventory, from_dict(to_dict(inventory, version=2), version=2))


### PR DESCRIPTION
This pull request includes several changes to improve inventory management and proxy version handling, as well as the addition of new tests. The most important changes include the introduction of versioning in `to_dict` and `from_dict` functions, updates to the proxy version, and the addition of utility functions to handle primitive types.

### Inventory Management Enhancements:
* [`speasy/core/inventory/indexes.py`](diffhunk://#diff-0aa4d4fe160642c4c462c689d7af654952247fe0096b3cd070ca98a9bc505efdL148-R193): Added a `version` parameter to the `to_dict`, `from_dict`, `to_json`, and `from_json` functions to support different versions of inventory serialization. [[1]](diffhunk://#diff-0aa4d4fe160642c4c462c689d7af654952247fe0096b3cd070ca98a9bc505efdL148-R193) [[2]](diffhunk://#diff-0aa4d4fe160642c4c462c689d7af654952247fe0096b3cd070ca98a9bc505efdL194-R215)
* [`speasy/data_providers/cda/_inventory_builder/__init__.py`](diffhunk://#diff-46c5a028db28a3ffd48597987ef4c1b68518d782fae9c5277d029db42d2ee0cdL40-R59): Updated various functions to use constants for inventory keys and added versioning support in `to_dict` and `from_dict` calls. [[1]](diffhunk://#diff-46c5a028db28a3ffd48597987ef4c1b68518d782fae9c5277d029db42d2ee0cdL40-R59) [[2]](diffhunk://#diff-46c5a028db28a3ffd48597987ef4c1b68518d782fae9c5277d029db42d2ee0cdL63-R73)
* [`speasy/data_providers/csa/__init__.py`](diffhunk://#diff-5d005b91c58a175623725738827dcafdedc14005e19c1bf407fafa5a1977540cR25-R36): Added the `_only_primitive_types` function to ensure metadata contains only primitive types before serialization. [[1]](diffhunk://#diff-5d005b91c58a175623725738827dcafdedc14005e19c1bf407fafa5a1977540cR25-R36) [[2]](diffhunk://#diff-5d005b91c58a175623725738827dcafdedc14005e19c1bf407fafa5a1977540cL41-R54)

### Proxy Version Update:
* [`speasy/core/proxy/__init__.py`](diffhunk://#diff-4d293ee7a631b3c2bd15103a6e043b8f8d3740d61e90366b944153ace4695af6L21-R21): Updated the `MINIMUM_REQUIRED_PROXY_VERSION` to "0.12.0" and added versioning support in the `get` function. [[1]](diffhunk://#diff-4d293ee7a631b3c2bd15103a6e043b8f8d3740d61e90366b944153ace4695af6L21-R21) [[2]](diffhunk://#diff-4d293ee7a631b3c2bd15103a6e043b8f8d3740d61e90366b944153ace4695af6R116-R123)

### Testing Enhancements:
* [`tests/test_inventories.py`](diffhunk://#diff-bb013097f40d98900591b87382627bae77a24eae762cbe7cce16021ebc95131dR1-R54): Added new tests to ensure that the `from_dict` and `to_dict` functions preserve the inventory structure and data accurately.