### PR TITLE
Quick fix for leftover additional_argument instead of product_inputs

### DIFF
--- a/speasy/data_providers/amda/ws.py
+++ b/speasy/data_providers/amda/ws.py
@@ -114,8 +114,8 @@ def _amda_get_proxy_parameter_args(start_time: datetime, stop_time: datetime, pr
     proxy_args = {'path': f"{amda_provider_name}/{product}", 'start_time': f'{start_time.isoformat()}',
                   'stop_time': f'{stop_time.isoformat()}',
                   'output_format': kwargs.get('output_format', amda_cfg.output_format.get())}
-    if kwargs.get('additional_arguments') and isinstance(kwargs.get('additional_arguments'), Dict):
-        proxy_args['additional_arguments'] = json.dumps(kwargs.get('additional_arguments'))
+    if kwargs.get('product_inputs') and isinstance(kwargs.get('product_inputs'), Dict):
+        proxy_args['product_inputs'] = json.dumps(kwargs.get('product_inputs'))
     return proxy_args
 
 


### PR DESCRIPTION
This pull request includes a change to the `speasy/data_providers/amda/ws.py` file to update the handling of proxy parameters. The most important change involves modifying the conditional check and key used for additional arguments.

Changes to proxy parameter handling:

* [`speasy/data_providers/amda/ws.py`](diffhunk://#diff-7fb717891684e55d92ba40db546e15f4c678df3dfc9fddeca532898fca88c5c9L117-R118): Updated the conditional check from `additional_arguments` to `product_inputs` and changed the key in the `proxy_args` dictionary accordingly.