### PR TITLE
Handles corner cases with Cluster CDF files

### DIFF
--- a/speasy/core/data_containers.py
+++ b/speasy/core/data_containers.py
@@ -218,7 +218,7 @@ class DataContainer(DataContainerProtocol['DataContainer']):
                 self.__name == other.__name and \
                 self.is_time_dependent == other.is_time_dependent and \
                 np.all(self.__values.shape == other.__values.shape) and \
-                np.array_equal(self.__values, other.__values, equal_nan=True)
+                np.array_equal(self.__values, other.__values, equal_nan=np.issubdtype(self.__values.dtype, np.floating))
         else:
             return self.__values.__eq__(other)
 

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -238,6 +238,17 @@ class SpecificNonRegression(unittest.TestCase):
             datetime(2018, 5, 26, 1, 0, 0), datetime(2018, 5, 26, 1, 10, 1))
         self.assertIsNotNone(result)
 
+    def test_get_cluster_fgm_data(self):
+        # should return None because the data is not available but should not raise an error
+        result = spz.get_data(spz.inventories.data_tree.cda.Cluster.C1.FGM_SPIN.C1_CP_FGM_SPIN.B_vec_xyz_gse__C1_CP_FGM_SPIN , "2018-03-02", "2018-03-03")
+        self.assertIsNone(result)
+
+        result = spz.get_data(spz.inventories.data_tree.cda.Cluster.C1.FGM_SPIN.C1_CP_FGM_SPIN.B_vec_xyz_gse__C1_CP_FGM_SPIN , "2016-03-02", "2016-03-03")
+        self.assertIsNone(result)
+
+        result = spz.get_data(spz.inventories.data_tree.cda.Cluster.C1.FGM_SPIN.C1_CP_FGM_SPIN.B_vec_xyz_gse__C1_CP_FGM_SPIN , "2015-03-02", "2015-03-03")
+        self.assertIsNotNone(result)
+
 
 @ddt
 class DirectArchiveConverter(unittest.TestCase):

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -80,7 +80,7 @@ class TestCDFWriter(unittest.TestCase):
     def setUpClass(cls):
         codec = get_codec("application/x-cdf")
         cls.v = codec.load_variable("BGSEc", codec.save_variables(
-            [codec.load_variable("BGSEc", f"{__HERE__}/resources/ac_k2_mfi_20220101_v03.cdf")]))
+            [codec.load_variable("BGSEc", f"{__HERE__}/resources/ac_k2_mfi_20220101_v03.cdf", disable_cache=True)]), disable_cache=True)
 
     def test_variable_is_loaded(self):
         self.assertIsNotNone(self.v)


### PR DESCRIPTION
This pull request includes several changes to the `speasy/core/codecs/bundled_codecs/istp_cdf.py` file, improvements to the `speasy/core/data_containers.py` file, and additional tests in the `tests/test_cdaweb.py` and `tests/test_codecs.py` files. The most important changes include adding new functions, modifying existing functions to handle specific conditions, and adding new test cases to ensure the robustness of the code.

### Enhancements to `istp_cdf.py`:

* Added import for `SupportDataVariable` from `pyistp.support_data_variable`.
* Introduced `_display_type` function to handle display type attributes in `DataVariable`.
* Added `_filter_extra_axes` function to filter out extra axes from `DataVariable`.
* Added `_valid_variable_or_none` function to handle fill values in epoch.
* Modified `_load_variable` function to use `_filter_extra_axes` and `_valid_variable_or_none` for better handling of variable data.

### Improvements to `data_containers.py`:

* Updated `__eq__` method in `DataContainer` to handle `equal_nan` condition based on the data type of `__values`.

### Additional test cases:

* Added `test_get_cluster_fgm_data` to `tests/test_cdaweb.py` to ensure proper handling of unavailable data without raising errors.
* Modified `setUpClass` method in `TestCDFWriter` class in `tests/test_codecs.py` to disable cache when loading variables.