### PR TITLE
CDAWeb inventory product node names were not cleanned

### DIFF
--- a/speasy/core/__init__.py
+++ b/speasy/core/__init__.py
@@ -322,7 +322,8 @@ def fix_name(name: str):
         ('(', ''),
         ('⊙', 'o'),
         (';', '_'),
-        (',', '_')
+        (',', '_'),
+        ('%', '_')
     )
     if len(name):
         if name[0].isnumeric():

--- a/speasy/data_providers/cda/_inventory_builder/_cdf_masters_parser.py
+++ b/speasy/data_providers/cda/_inventory_builder/_cdf_masters_parser.py
@@ -5,6 +5,7 @@ import pyistp
 
 from speasy.core.cdf.inventory_extractor import extract_parameters, filter_dataset_meta
 from speasy.core.inventory.indexes import ParameterIndex, DatasetIndex, SpeasyIndex
+from speasy.core import fix_name
 
 log = logging.getLogger(__name__)
 
@@ -19,7 +20,7 @@ def _patch_parameter(parameter: ParameterIndex, dataset: DatasetIndex):
 def load_master_cdf(path, dataset: DatasetIndex):
     cdf = pyistp.loader.ISTPLoader(path)
     dataset.__dict__.update(
-        {p.spz_name(): p for p in
+        {fix_name(p.spz_name()): p for p in
          map(lambda p: _patch_parameter(p, dataset), extract_parameters(cdf, provider="cda",
                                                                         uid_fmt=f"{dataset.serviceprovider_ID}/{{var_name}}"))})
     dataset.__dict__.update(filter_dataset_meta(cdf))


### PR DESCRIPTION
This pull request includes several changes to improve the handling of names with special characters and to enhance the test coverage for the `speasy` package. The most important changes include the addition of a new character replacement in the `fix_name` function, the integration of this function into the `_cdf_masters_parser`, and the introduction of a utility function to reset cache flags in tests.

### Improvements to name handling:

* [`speasy/core/__init__.py`](diffhunk://#diff-2ea3f222debe7d37c3203de600be333ce5d09ff853a18409fe985509d73d4ae1L325-R326): Added a replacement for the '%' character with an underscore in the `fix_name` function.
* [`speasy/data_providers/cda/_inventory_builder/_cdf_masters_parser.py`](diffhunk://#diff-6c47903d6b33858f327b06987521b4c829684220cf999ccb3698ff9929a2d016L22-R23): Integrated the `fix_name` function to sanitize parameter names when loading master CDF files.

### Enhancements to testing:

* [`tests/test_cdaweb.py`](diffhunk://#diff-5351aaabac8e34ff531a0f6b46d8b92c83e9f72a504c6068c6d76b299d1eda7eR15-R20): Added a new utility function `reset_cda_inventory_cache_flags` to reset cache flags, improving test setup and teardown.
* [`tests/test_cdaweb.py`](diffhunk://#diff-5351aaabac8e34ff531a0f6b46d8b92c83e9f72a504c6068c6d76b299d1eda7eL181-R187): Updated the `test_can_get_full_inventory_without_proxy` test to use the new `reset_cda_inventory_cache_flags` function.
* [`tests/test_cdaweb.py`](diffhunk://#diff-5351aaabac8e34ff531a0f6b46d8b92c83e9f72a504c6068c6d76b299d1eda7eR268-R277): Added a new test `test_get_products_with_percent_in_name` to ensure that products with '%' in their name are handled correctly.

Closes #211