### PR TITLE
Fixes #214

### DIFF
--- a/speasy/products/variable.py
+++ b/speasy/products/variable.py
@@ -792,24 +792,23 @@ class SpeasyVariable(SpeasyProduct):
         else:
             res = deepcopy(self)
 
-        indexes_without_nan = None
-        indexes_without_fill = None
-        indexes_without_invalid = None
+        indexes = []
         if drop_nan_and_inf:
-            indexes_without_nan = np.isfinite(res).reshape(-1)
+            indexes.append(np.isfinite(res).reshape(-1))
         if drop_fill_values and res.fill_value is not None:
-            indexes_without_fill = np.all(res != res.fill_value, axis=tuple(range(1, res.ndim)))
+            indexes.append(np.all(res != res.fill_value, axis=tuple(range(1, res.ndim))))
         if drop_out_of_range_values:
             valid_min = valid_min or res.valid_range[0]
             valid_max = valid_max or res.valid_range[1]
             if valid_min is not None and valid_max is not None:
-                indexes_without_invalid = np.logical_and(
+                indexes.append(np.logical_and(
                     res >= valid_min, res <= valid_max
-                ).reshape(-1)
+                ).reshape(-1))
+        if len(indexes) == 0:
+            raise ValueError(
+                "No filtering applied, please set at least one of drop_fill_values, drop_out_of_range_values or drop_nan_and_inf to True")
         return res[
-            np.logical_and(
-                indexes_without_nan, indexes_without_fill, indexes_without_invalid
-            )
+            np.logical_and.reduce(indexes)
         ]
 
     @staticmethod

--- a/speasy/products/variable.py
+++ b/speasy/products/variable.py
@@ -758,8 +758,8 @@ class SpeasyVariable(SpeasyProduct):
         res[np.logical_or(res > valid_max, res < valid_min)] = np.nan
         return res
 
-    def sanitized(self, drop_fill_values=True, drop_out_of_range_values=True, drop_nan_and_inf=True, inplace=False,
-                  valid_min=None, valid_max=None) -> "SpeasyVariable":
+    def sanitized(self, drop_fill_values=True, drop_out_of_range_values=True, drop_nan_and_inf=True, valid_min=None,
+                  valid_max=None) -> "SpeasyVariable":
         """Returns a copy of the variable with fill values and invalid values removed
 
         Parameters
@@ -770,8 +770,6 @@ class SpeasyVariable(SpeasyProduct):
             Remove values outside valid range, by default True
         drop_nan_and_inf : bool, optional
             Remove NaN and Infinite values, by default True
-        inplace : bool, optional
-            Modifies source variable when true else modifies and returns a copy, by default False
         valid_min : Float, optional
             Minimum valid value, takes metadata field "VALIDMIN" if not provided, by default None
         valid_max : Float, optional
@@ -787,27 +785,22 @@ class SpeasyVariable(SpeasyProduct):
         replace_fillval_by_nan: replaces fill values by NaN
         clamp_with_nan: replaces values outside valid range by NaN
         """
-        if inplace:
-            res = self
-        else:
-            res = deepcopy(self)
-
         indexes = []
         if drop_nan_and_inf:
-            indexes.append(np.isfinite(res).reshape(-1))
-        if drop_fill_values and res.fill_value is not None:
-            indexes.append(np.all(res != res.fill_value, axis=tuple(range(1, res.ndim))))
+            indexes.append(np.isfinite(self).reshape(-1))
+        if drop_fill_values and self.fill_value is not None:
+            indexes.append(np.all(self != self.fill_value, axis=tuple(range(1, self.ndim))))
         if drop_out_of_range_values:
-            valid_min = valid_min or res.valid_range[0]
-            valid_max = valid_max or res.valid_range[1]
+            valid_min = valid_min or self.valid_range[0]
+            valid_max = valid_max or self.valid_range[1]
             if valid_min is not None and valid_max is not None:
                 indexes.append(np.logical_and(
-                    res >= valid_min, res <= valid_max
+                    self >= valid_min, self <= valid_max
                 ).reshape(-1))
         if len(indexes) == 0:
             raise ValueError(
                 "No filtering applied, please set at least one of drop_fill_values, drop_out_of_range_values or drop_nan_and_inf to True")
-        return res[
+        return self[
             np.logical_and.reduce(indexes)
         ]
 

--- a/tests/test_speasy_variable.py
+++ b/tests/test_speasy_variable.py
@@ -371,11 +371,13 @@ class ASpeasyVariable(unittest.TestCase):
 
     def test_non_regression_214(self):
         # see https://github.com/SciQLop/speasy/issues/214
-        import  speasy as spz
+        import speasy as spz
         r = spz.get_data("amda/imf", "2016-6-2", "2016-6-5").sanitized(drop_fill_values=False)
         self.assertIsNotNone(r)
-        r = spz.get_data("amda/imf", "2016-6-2", "2016-6-5").sanitized(drop_fill_values=False, drop_out_of_range_values=False)
+        r = spz.get_data("amda/imf", "2016-6-2", "2016-6-5").sanitized(drop_fill_values=False,
+                                                                       drop_out_of_range_values=False)
         self.assertIsNotNone(r)
+
 
 class TestSpeasyVariableMath(unittest.TestCase):
     def setUp(self):

--- a/tests/test_speasy_variable.py
+++ b/tests/test_speasy_variable.py
@@ -366,7 +366,16 @@ class ASpeasyVariable(unittest.TestCase):
         cleaned_copy = var.sanitized()
         self.assertFalse(np.any(np.isnan(cleaned_copy.values)))
         self.assertLess(len(cleaned_copy), len(var))
+        with self.assertRaises(ValueError):
+            var.sanitized(drop_fill_values=False, drop_out_of_range_values=False, drop_nan_and_inf=False)
 
+    def test_non_regression_214(self):
+        # see https://github.com/SciQLop/speasy/issues/214
+        import  speasy as spz
+        r = spz.get_data("amda/imf", "2016-6-2", "2016-6-5").sanitized(drop_fill_values=False)
+        self.assertIsNotNone(r)
+        r = spz.get_data("amda/imf", "2016-6-2", "2016-6-5").sanitized(drop_fill_values=False, drop_out_of_range_values=False)
+        self.assertIsNotNone(r)
 
 class TestSpeasyVariableMath(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This pull request refactors the `sanitized` method in `speasy/products/variable.py` to improve clarity and efficiency, removes the `inplace` parameter, and updates the corresponding tests to ensure robustness. The most important changes are summarized below:

### Refactoring and Parameter Removal:

* Removed the `inplace` parameter from the `sanitized` method, simplifying its functionality to always return a new filtered copy of the variable. [[1]](diffhunk://#diff-85f04bb7467121cc0c8346b1abcfc51def0e90587138125e1e50f9953f6690f4L761-R762) [[2]](diffhunk://#diff-85f04bb7467121cc0c8346b1abcfc51def0e90587138125e1e50f9953f6690f4L773-L774)
* Refactored the filtering logic in the `sanitized` method to use a list of conditions (`indexes`) and `np.logical_and.reduce`, improving code readability and efficiency.

### Error Handling:

* Added a validation step in the `sanitized` method to raise a `ValueError` if no filtering options (`drop_fill_values`, `drop_out_of_range_values`, or `drop_nan_and_inf`) are enabled. This prevents unintended behavior.

### Testing Enhancements:

* Updated tests in `tests/test_speasy_variable.py` to include a check for the new `ValueError` when no filtering options are set.
* Added a non-regression test (`test_non_regression_214`) to ensure the `sanitized` method works correctly for specific use cases related to issue #214.This pull request refactors the `sanitized` method in `speasy/products/variable.py` to simplify the logic for combining filtering conditions and adds new test cases to ensure robustness. The changes improve code maintainability and enhance the reliability of the `sanitized` method.

### Refactoring of `sanitized` method:

* Simplified the logic for combining filtering conditions by replacing individual index variables (`indexes_without_nan`, `indexes_without_fill`, `indexes_without_invalid`) with a single `indexes` list and using `np.logical_and.reduce` to combine conditions.
* Added a validation step to raise a `ValueError` if no filtering options (`drop_fill_values`, `drop_out_of_range_values`, `drop_nan_and_inf`) are enabled.

### Enhancements to test coverage:

* Updated the `test_cleans` method to include a test case that verifies a `ValueError` is raised when all filtering options are disabled.
* Added a new test case, `test_non_regression_214`, to ensure the `sanitized` method works correctly with specific configurations and resolves a previously reported issue (#214).