### PR TITLE
Fixes CI issues on #215 and #216

### DIFF
--- a/docs/user/sscweb/sscweb.rst
+++ b/docs/user/sscweb/sscweb.rst
@@ -15,9 +15,9 @@ First you need to ensure that the trajectory you want to get is available with t
 speasy dynamic inventory so you will always get an up to date inventory:
 
     >>> import speasy as spz
-    >>> # Let's only print the first 10 trajectories
+    >>> # Let's only print the first 10 objects
     >>> print(list(spz.inventories.flat_inventories.ssc.parameters.keys())[:10])
-    ['ace', 'active', 'aec', 'aed', 'aee', 'aerocube6a', 'aerocube6b', 'aim', 'akebono', 'alouette1']
+    ['ace', 'active', 'adityal1', 'aec', 'aed', 'aee', 'aerocube6a', 'aerocube6b', 'aim', 'akebono']
 
 Note that you can also use your python terminal completion and browse `spz.inventories.data_tree.ssc.Trajectories` to find
 your trajectory.

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -57,7 +57,7 @@ class DirectArchiveDownloader(unittest.TestCase):
 
     @data(
         (
-            "https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v04_08.cdf",
+            "https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v04_09.cdf",
             "regular", "ne_mgf", "2018-02-01", "2018-02-02"),
         (
             "http://themis.ssl.berkeley.edu/data/themis/thb/l2/scm/{Y}/thb_l2_scm_{Y}{M:02d}{D:02d}_v01.cdf",
@@ -78,7 +78,7 @@ class DirectArchiveDownloader(unittest.TestCase):
 
     def test_get_product_with_custom_loader(self):
         v = get_product(
-            url_pattern="https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v04_08.cdf",
+            url_pattern="https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v04_09.cdf",
             split_rule="regular",
             variable="ne_mgf", start_time="2018-02-01", stop_time="2018-02-02",
             file_reader=_custom_cdf_loader)
@@ -86,7 +86,7 @@ class DirectArchiveDownloader(unittest.TestCase):
         self.assertTrue(v.meta.get("_custom_cdf_loader"))
 
     @data(
-        "https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/2018/erg_pwe_hfa_l3_1min_20180102_v04_08.cdf",
+        "https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3_1min/2018/erg_pwe_hfa_l3_1min_20180102_v04_09.cdf",
         "http://themis.ssl.berkeley.edu/data/themis/thb/l2/gmom/0000/thb_l2_gmom_00000000_v01.cdf",
         "https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/erg_orb_l3_t89_00000000_v01.cdf"
 


### PR DESCRIPTION
This pull request updates the test cases in `tests/test_direct_archive_downloader.py` to reflect a version change in the URL patterns for the `erg_pwe_hfa_l3_1min` dataset. The version has been incremented from `v04_08` to `v04_09`.

### Test case updates for URL version change:

* Updated the URL pattern in `test_unknown_split_rules_raises` to use `v04_09` instead of `v04_08`.
* Updated the URL patterns in `test_download_existing_data` to reflect the version change from `v04_08` to `v04_09`.