### PR TITLE
Add HTTP basic auth support using netrc file

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+    - name: add test logins
+      uses: extractions/netrc@v2
+      with:
+        machine: authenticationtest.com
+        username: user
+        password: pass
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+    -   name: add test logins
+        uses: extractions/netrc@v2
+        with:
+            machine: authenticationtest.com
+            username: user
+            password: pass
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/tests/test_http_module.py
+++ b/tests/test_http_module.py
@@ -20,7 +20,6 @@ class HttpTests(unittest.TestCase):
     def tearDown(self):
         pass
 
-
     @data(
         ("http://somewhere-that-does-not-exist-404.com", False),
         ("https://hephaistos.lpp.polytechnique.fr", True),
@@ -29,6 +28,16 @@ class HttpTests(unittest.TestCase):
     @unpack
     def test_is_up(self, url, expected):
         self.assertEqual(is_server_up(url), expected)
+
+    def test_basic_http_auth(self):
+        # https://authenticationtest.com/HTTPAuth/
+        import netrc
+        netrc_info = netrc.netrc()
+        if netrc_info.authenticators("authenticationtest.com"):
+            from speasy.core import http
+            self.assertEqual(http.get("https://authenticationtest.com/HTTPAuth/").status_code, 200)
+        else:
+            self.skipTest("Netrc authenticator not available")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request introduces changes to implement HTTP Basic Authentication using `.netrc` files, updates the HTTP request handling logic, and adds corresponding tests. The most important changes include adding support for authentication headers, refactoring HTTP header construction, and enhancing test coverage.

### Authentication Enhancements:
* Added a new `auth_header` function in `speasy/core/http.py` to generate HTTP Basic Authentication headers based on `.netrc` file entries. This function is cached for performance optimization.
* Integrated the `auth_header` function into a new `_build_headers` utility function, which constructs request headers, including authentication information.

### HTTP Request Refactoring:
* Updated the `_HttpVerb.__call__` and `urlopen` methods in `speasy/core/http.py` to use `_build_headers` for consistent header construction. This ensures that authentication headers are included when applicable. [[1]](diffhunk://#diff-d90d69ee5641adcbeebb6a908d8644c9d0c755b5b021a3e32af6114f721570e0L96-R116) [[2]](diffhunk://#diff-d90d69ee5641adcbeebb6a908d8644c9d0c755b5b021a3e32af6114f721570e0L107-R125)
* Changed the `Response` class to use `urllib3.response.BaseHTTPResponse` instead of `urllib3.response.HTTPResponse` for broader compatibility.

### Test Coverage:
* Added a new test, `test_basic_http_auth`, in `tests/test_http_module.py` to validate HTTP Basic Authentication using `.netrc` credentials. The test is skipped if no `.netrc` authenticator is available.

### Workflow Updates:
* Modified `.github/workflows/PRs.yml` and `.github/workflows/tests.yml` to include a step for adding test `.netrc` logins, enabling authentication during CI runs. [[1]](diffhunk://#diff-179fce2c77353dccbc875baddaaafe356619b8aedba77175ae577677bdfabc77R26-R31) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR26-R31)