### PR TITLE
Skip auth http test also if there is no netrc file and bi-weekly CI run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,10 @@
 name: Tests
 
-on: [push]
+on:
+    push:
+    schedule:
+        # Runs at 04:00 UTC on Mondays and Wednesday
+        -   cron: "0 4 * * 1,3"
 
 jobs:
   build:

--- a/tests/test_http_module.py
+++ b/tests/test_http_module.py
@@ -31,8 +31,13 @@ class HttpTests(unittest.TestCase):
 
     def test_basic_http_auth(self):
         # https://authenticationtest.com/HTTPAuth/
+
         import netrc
-        netrc_info = netrc.netrc()
+        try:
+            netrc_info = netrc.netrc()
+        except FileNotFoundError:
+            self.skipTest("Netrc file not found, skipping test")
+
         if netrc_info.authenticators("authenticationtest.com"):
             from speasy.core import http
             self.assertEqual(http.get("https://authenticationtest.com/HTTPAuth/").status_code, 200)


### PR DESCRIPTION
This pull request updates the `test_basic_http_auth` method in `tests/test_http_module.py` to handle cases where a `.netrc` file is missing. The change ensures the test is skipped gracefully if the file is not found.

* **Improved test robustness:**
  * Added a `try-except` block to handle `FileNotFoundError` when attempting to load the `.netrc` file. If the file is not found, the test is skipped with an appropriate message. (`[tests/test_http_module.pyR34-R40](diffhunk://#diff-7c47365ed30bf8b20ad8a1b1b40c08b09f0cc8db176358054297941fe5771a52R34-R40)`)