### PR TITLE
Add user agent config bit and set it for GH actions

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -54,6 +54,7 @@ jobs:
         SPEASY_LONG_TESTS: ""
         SPEASY_INVENTORY_TESTS: ""
         SPEASY_CORE_HTTP_REWRITE_RULES: '{"https://thisserver_does_not_exists.lpp.polytechnique.fr/pub/":"http://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/"}'
+        SPEASY_CORE_HTTP_USER_AGENT: "speasy-test-github-actions"
       run: |
         sudo apt update && sudo apt install -y texlive pandoc
         pip install pytest pytest-cov sphinx pandoc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,7 @@ jobs:
         SPEASY_LONG_TESTS: ""
         SPEASY_INVENTORY_TESTS: ""
         SPEASY_CORE_HTTP_REWRITE_RULES: '{"https://thisserver_does_not_exists.lpp.polytechnique.fr/pub/":"http://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/"}'
+        SPEASY_CORE_HTTP_USER_AGENT: "speasy-test-github-actions"
       run: |
         sudo apt update && sudo apt install -y texlive pandoc
         pip install pytest pytest-cov sphinx pandoc

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -166,6 +166,10 @@ The main benefit of disabling providers is to speedup speasy loading.""",
 The keys are the URL to match and the values are the replacement URL.
 Example: {"http://example.com": "http://localhost:8000"}""",
                          "type_ctor": _load_dict_from_repr},
+                     http_user_agent={"default": "",
+                                        "description": """User agent to use for HTTP requests.
+This is useful to identify the application making the request.
+If not set, it will use the default user agent of the speasy package."""},
                      urlib_pool_size={"default": 10,
                                       "description": """Sets the maximum number of connections to keep in the pool.
 This is useful to avoid creating a new connection for each request.""",

--- a/speasy/core/http.py
+++ b/speasy/core/http.py
@@ -17,7 +17,7 @@ from .url_utils import host_and_port, ApplyRewriteRules
 
 log = logging.getLogger(__name__)
 
-USER_AGENT = f'Speasy/{__version__} {platform.uname()} (SciQLop project)'
+USER_AGENT = core_config.http_user_agent.get() or f'Speasy/{__version__} {platform.uname()} (SciQLop project)'
 
 DEFAULT_TIMEOUT = 60  # seconds
 


### PR DESCRIPTION
This pull request introduces a new configuration option for setting a custom HTTP user agent in the `speasy` package. The changes ensure that the user agent can be customized for HTTP requests, improving identification and compatibility for specific use cases. Updates were made across configuration files and core functionality.

### Configuration Updates:

* `.github/workflows/PRs.yml` and `.github/workflows/tests.yml`: Added the `SPEASY_CORE_HTTP_USER_AGENT` environment variable to define a custom user agent for GitHub Actions workflows. [[1]](diffhunk://#diff-179fce2c77353dccbc875baddaaafe356619b8aedba77175ae577677bdfabc77R57) [[2]](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fR63)
* [`speasy/config/__init__.py`](diffhunk://#diff-6c2d9f868a7e957248ebcb3f5ff2761c3d82a844211a1f06e8cd83889d4f61d6R169-R172): Introduced a new configuration entry `http_user_agent` with a default value and description, allowing users to set a custom user agent for HTTP requests.

### Core Functionality Updates:

* [`speasy/core/http.py`](diffhunk://#diff-d90d69ee5641adcbeebb6a908d8644c9d0c755b5b021a3e32af6114f721570e0L20-R20): Updated the `USER_AGENT` variable to use the custom value from `core_config.http_user_agent` if set; otherwise, it defaults to the existing user agent format.