### PR TITLE
Slicing a variable by columns did break with secondary axis

### DIFF
--- a/speasy/products/variable.py
+++ b/speasy/products/variable.py
@@ -213,8 +213,16 @@ class SpeasyVariable(SpeasyProduct):
             a SpeasyVariable with only selected columns
         """
         indexes = list(map(lambda v: self.__columns.index(v), columns))
+        if len(self.__axes) == 1:
+            axes = deepcopy(self.__axes)
+        elif len(self.__axes) == 2:
+            axes = [deepcopy(self.__axes[0]),
+                    deepcopy(self.__axes[1][indexes])]
+        else:
+            raise ValueError("filter_columns is only supported for table-like variables with 1 or 2 axes")
+
         return SpeasyVariable(
-            axes=deepcopy(self.__axes),
+            axes=axes,
             values=DataContainer(
                 is_time_dependent=self.__values_container.is_time_dependent,
                 name=self.__values_container.name,


### PR DESCRIPTION
This pull request enhances column filtering functionality in the `SpeasyVariable` class and adds comprehensive tests to ensure robust behavior. The changes primarily focus on supporting table-like variables with 1 or 2 axes and improving test coverage for edge cases and regressions.

### Enhancements to column filtering in `SpeasyVariable`:

* [`speasy/products/variable.py`](diffhunk://#diff-85f04bb7467121cc0c8346b1abcfc51def0e90587138125e1e50f9953f6690f4R216-R225): Updated the `filter_columns` method to handle cases where the variable has 1 or 2 axes. Added validation to raise a `ValueError` for unsupported cases, ensuring the method is restricted to table-like variables.

### Improved test coverage:

* [`tests/test_speasy_variable.py`](diffhunk://#diff-ea55fab2fa51a9b6c44fb4455ca6b06ba7d5736f4e905a488d190db6cbea3911R169-R175): Added a new test case, `test_cant_slice_columns_a_3d_variable`, to verify that attempting to filter columns on a 3D variable raises a `ValueError` with the correct error message.
* [`tests/test_speasy_variable.py`](diffhunk://#diff-ea55fab2fa51a9b6c44fb4455ca6b06ba7d5736f4e905a488d190db6cbea3911R419-R431): Introduced `test_non_regression_select_column` to validate column selection behavior and ensure non-regression for specific scenarios involving single and multiple column selection.