### PR TITLE
Always use certifi provided certificates bundle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ dependencies = ['PyYAML',
  'requests',
  'scipy',
  'tqdm',
- 'urllib3>=1.26.0']
+ 'urllib3>=1.26.0',
+ 'certifi'
+]
 
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ urllib3>=1.26.0
 pyistp>=0.7.0
 scipy
 tqdm
+certifi

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,3 +20,4 @@ pyistp>=0.7.0
 scipy
 tqdm
 watchdog
+certifi

--- a/speasy/core/http.py
+++ b/speasy/core/http.py
@@ -9,6 +9,7 @@ from typing import Optional, Dict
 import urllib3.response
 from urllib3 import PoolManager
 from urllib3.util.retry import Retry
+import certifi
 import netrc
 
 from speasy import __version__
@@ -31,7 +32,8 @@ RETRY_AFTER_LIST = [429, 503]  # Note: Specific treatment for 429 & 503 error co
 
 _HREF_REGEX = re.compile(' href="([A-Za-z0-9.-_]+)">')
 
-pool = PoolManager(num_pools=core_config.urlib_num_pools.get(), maxsize=core_config.urlib_pool_size.get())
+pool = PoolManager(num_pools=core_config.urlib_num_pools.get(), maxsize=core_config.urlib_pool_size.get(),
+                   cert_reqs='CERT_REQUIRED', ca_certs=certifi.where())
 
 
 class Response:


### PR DESCRIPTION
This pull request adds support for certificate verification to HTTP requests in the project by introducing the `certifi` library as a dependency and updating the HTTP connection pool configuration. The main changes include updating dependency files and modifying the initialization of the `PoolManager` to use certificate verification.

**Dependency updates:**

* Added `certifi` to the `dependencies` list in `pyproject.toml` and to `requirements_dev.txt` to ensure the package is available for both runtime and development environments. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L49-R51) [[2]](diffhunk://#diff-c9c796259f3852b51b531b79cbf07820145088d4f108fb006ab44b15f0b15934R23)

**HTTP connection security improvements:**

* Imported `certifi` in `speasy/core/http.py` to access certificate authority data.
* Updated the creation of the `PoolManager` in `speasy/core/http.py` to require certificate verification (`cert_reqs='CERT_REQUIRED'`) and use the CA certificates provided by `certifi`.