### PR TITLE
Is VIRTUAL any product that is VIRTUAL or has a VIRTUAL support data axis

### DIFF
--- a/speasy/data_providers/cda/__init__.py
+++ b/speasy/data_providers/cda/__init__.py
@@ -10,6 +10,7 @@ import logging
 import re
 from datetime import datetime, timedelta
 from typing import Dict, Optional, Tuple
+from packaging.version import Version
 
 from speasy.core import AllowedKwargs, EnsureUTCDateTime
 from speasy.core import http, url_utils
@@ -75,7 +76,7 @@ class CdaWebservice(DataProvider):
 
     def __init__(self):
         self.__url = f"{self.BASE_URL}/WS/cdasr/1"
-        DataProvider.__init__(self, provider_name='cda', provider_alt_names=['cdaweb'])
+        DataProvider.__init__(self, provider_name='cda', provider_alt_names=['cdaweb'], min_proxy_version=Version("0.13.0"))
         self._cdf_codec = get_codec('application/x-cdf')
 
     def build_inventory(self, root: SpeasyIndex):

--- a/speasy/data_providers/cda/_inventory_builder/_cdf_masters_parser.py
+++ b/speasy/data_providers/cda/_inventory_builder/_cdf_masters_parser.py
@@ -22,7 +22,12 @@ def load_master_cdf(path, dataset: DatasetIndex):
     dataset.__dict__.update(
         {fix_name(p.spz_name()): p for p in
          map(lambda p: _patch_parameter(p, dataset), extract_parameters(cdf, provider="cda",
-                                                                        uid_fmt=f"{dataset.serviceprovider_ID}/{{var_name}}"))})
+                                                                        uid_fmt=f"{dataset.serviceprovider_ID}/{{var_name}}",
+                                                                        enable_cda_trick=True
+                                                                        )
+             )
+         }
+    )
     dataset.__dict__.update(filter_dataset_meta(cdf))
 
 

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -292,10 +292,10 @@ class SpecificNonRegression(unittest.TestCase):
         self.assertIsNotNone(data_sum_1)
         self.assertIsNotNone(data_sum_2)
 
-    @unittest.expectedFailure
     def test_get_WI_SFSP_3DP(self):
         # https://github.com/SciQLop/speasy/issues/225
         os.environ[spz.config.proxy.enabled.env_var_name] = "False"
+        self.assertEqual(spz.inventories.tree.cda.Wind.WIND.n_3DP.WI_SFSP_3DP.FLUX.VIRTUAL.lower(), "true")
         data = spz.get_data("cda/WI_SFSP_3DP/FLUX", "2005-01-01", "2005-01-01T01")
         self.assertIsNotNone(data)
 

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -97,6 +97,17 @@ class DirectArchiveDownloader(unittest.TestCase):
             provider="test")
         self.assertGreater(len(parameters), 0)
 
+    def test_build_inventory_from_remote_cdf_cda_trick(self):
+        parameters = extract_parameters(
+            url_or_istp_loader="https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/wi_sfsp_3dp_00000000_v01.cdf",
+            provider="cda",
+            enable_cda_trick=True
+        )
+        self.assertGreater(len(parameters), 0)
+        for p in parameters:
+            if p.spz_name() == "FLUX":
+                self.assertEqual(p.VIRTUAL.lower(), "true")
+
     @data(
         # (spz.inventories.data_tree.archive.cda.Arase_ERG.PWE.HFA.erg_pwe_hfa_l3_1min.ne_mgf, "2018-01-06T10",
         # "2018-01-06T12"),


### PR DESCRIPTION
This pull request introduces a new mechanism ("CDA trick") to improve the handling and identification of virtual variables in CDF datasets, specifically for the CDAWeb data provider. The changes add an option to propagate virtual attribute detection through dependent axes and ensure this metadata is correctly surfaced in inventories and tests. Additionally, minimum proxy version requirements are set for the CDA provider.

**Virtual variable detection and propagation:**
* Added the `enable_cda_trick` parameter to `extract_parameter`, `_extract_parameters_impl`, and `extract_parameters` functions in `speasy/core/cdf/inventory_extractor.py`, enabling enhanced detection of virtual variables by checking both the variable and its axes for the `VIRTUAL` attribute. [[1]](diffhunk://#diff-144b8225e23dcd9227317534939721b36b836629322c994b0728563058b502d1L39-R51) [[2]](diffhunk://#diff-144b8225e23dcd9227317534939721b36b836629322c994b0728563058b502d1L53-R73)
* Updated `load_master_cdf` in `speasy/data_providers/cda/_inventory_builder/_cdf_masters_parser.py` to use the CDA trick when extracting parameters, ensuring virtual variable metadata is captured.

**Provider requirements:**
* Set a minimum proxy version (`0.13.0`) for the CDA provider in `speasy/data_providers/cda/__init__.py` by using the `Version` class and updating the provider initialization. [[1]](diffhunk://#diff-f342edc6a31dbdb904f1e2c7d9ac1fca726ea56e89a27eabff6966f857ec00f8R13) [[2]](diffhunk://#diff-f342edc6a31dbdb904f1e2c7d9ac1fca726ea56e89a27eabff6966f857ec00f8L78-R79)

**Testing and validation:**
* Added and updated tests in `tests/test_cdaweb.py` and `tests/test_direct_archive_downloader.py` to validate the correct identification of virtual variables when the CDA trick is enabled, including explicit assertions for the `VIRTUAL` metadata. [[1]](diffhunk://#diff-5351aaabac8e34ff531a0f6b46d8b92c83e9f72a504c6068c6d76b299d1eda7eL295-R298) [[2]](diffhunk://#diff-a32ed2766b3c6b71a213659042c291b30650f211528368d3ef754d9e9b3d3aeaR100-R110)