### PR TITLE
[UiowaEphTool] products are registered with UiowaEphTool as provider

### DIFF
--- a/speasy/core/requests_scheduling/request_dispatch.py
+++ b/speasy/core/requests_scheduling/request_dispatch.py
@@ -96,6 +96,7 @@ def init_uiowaephtool(ignore_disabled_status=False):
             uiowaephtool = UiowaEphTool()
             sys.modules[__name__].uiowaephtool = uiowaephtool
             PROVIDERS['uiowaephtool'] = uiowaephtool
+            PROVIDERS['UiowaEphTool'] = uiowaephtool
         else:
             log.warning("UiowaEphTool server https://planet.physics.uiowa.edu is down, disabling UiowaEphTool provider")
 

--- a/tests/test_speasy.py
+++ b/tests/test_speasy.py
@@ -127,7 +127,7 @@ class SpeasyModule(unittest.TestCase):
     def test_can_list_providers(self):
         l = spz.list_providers()
         self.assertListEqual(
-            sorted(l), sorted(['amda', 'cdaweb', 'cda', 'sscweb', 'ssc', 'csa', 'archive', 'generic_archive', 'uiowaephtool']))
+            sorted(l), sorted(['amda', 'cdaweb', 'cda', 'sscweb', 'ssc', 'csa', 'archive', 'generic_archive', 'uiowaephtool', 'UiowaEphTool']))
 
     @data(*[(provider,) for provider in PROVIDERS.keys()])
     @unpack


### PR DESCRIPTION
This pull request introduces a small update to the provider registration logic in the `init_uiowaephtool` function. The change ensures that the `UiowaEphTool` provider is registered under both the lowercase and camel-case keys in the `PROVIDERS` dictionary, improving consistency and compatibility.

* Registration update:
  * [`speasy/core/requests_scheduling/request_dispatch.py`](diffhunk://#diff-5aa38a31965b762909190b5464c52b1f5134f217804442f2b7e5f206fe25d85dR99): Added `PROVIDERS['UiowaEphTool'] = uiowaephtool` to register the provider under both possible key formats.