### PR TITLE
Increase proxy request timeout from 1 minute (default) to 5 minutes

### DIFF
--- a/speasy/core/proxy/__init__.py
+++ b/speasy/core/proxy/__init__.py
@@ -91,7 +91,7 @@ class GetProduct:
         kwargs['stop_time'] = stop_time
         kwargs['format'] = 'python_dict'
         kwargs['zstd_compression'] = zstd_compression
-        resp = http.get(f"{url}/get_data", params=kwargs)
+        resp = http.get(f"{url}/get_data", params=kwargs, timeout=60*5)
         log.debug(f"Asking data from proxy {resp.url}, {resp.headers}")
         if resp.status_code == 200:
             var = var_from_dict(pickle.loads(decompress(resp.bytes)))


### PR DESCRIPTION
This will help for quite long requests on AMDA where Speasy and the proxy might retry after one minute while AMDA is still processing the current request thus increasing the number of requests and making AMDA even slower.