### PR TITLE
Unlike the documentation says socks does not only return ProxyError

### DIFF
--- a/speasy/core/http.py
+++ b/speasy/core/http.py
@@ -241,7 +241,7 @@ def is_server_up(url: Optional[str] = None, host: Optional[str] = None, port: Op
             sock.connect((host, int(port)))
             sock.close()
             return True
-        except socks.ProxyError:
+        except (socks.ProxyError, OSError):
             log.debug(f"Server {host}:{port} not up yet, retrying in 1 second")
             time.sleep(1.)
     return False


### PR DESCRIPTION
This pull request improves error handling in the `is_server_up` function within `speasy/core/http.py` by broadening the exception handling to cover additional network-related errors.

Error handling improvement:

* Updated the exception block in `is_server_up` to catch both `socks.ProxyError` and `OSError`, ensuring that connection failures due to general socket errors are properly handled and retried.