### PR TITLE
Use HTTPS everywhere possible (HTTP is rejected within WASM)

### DIFF
--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -161,7 +161,7 @@ core = ConfigSection("CORE",
 The main benefit of disabling providers is to speedup speasy loading.""",
                                          "type_ctor": lambda x: set(x.split(','))},
                      http_rewrite_rules={"default": {
-                         "https://cdaweb.gsfc.nasa.gov/pub/": "http://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/"},
+                         "https://cdaweb.gsfc.nasa.gov/pub/": "https://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/"},
                          "description": """A dictionary of rules to rewrite URLs before sending requests.
 The keys are the URL to match and the values are the replacement URL.
 Example: {"http://example.com": "http://localhost:8000"}""",

--- a/speasy/core/proxy/__init__.py
+++ b/speasy/core/proxy/__init__.py
@@ -26,7 +26,7 @@ if proxy_cfg.url() == "" or proxy_cfg.enabled() == False:
 use the following python snippet to configure proxy server:
 ===========================================================================
 import speasy as spz
-spz.config.proxy.url.set("http://sciqlop.lpp.polytechnique.fr/cache")
+spz.config.proxy.url.set("https://sciqlop.lpp.polytechnique.fr/cache")
 spz.config.proxy.enabled.set(True)
 ===========================================================================
             """, stacklevel=0)


### PR DESCRIPTION
This pull request updates the configuration to use secure HTTPS URLs instead of HTTP for both the CDAWeb data rewrite rule and the proxy server. This change makes Speasy closer to run inside JupyterLite, most issues so far are HTTP and CORS.

Configuration updates for secure connections:

* Changed the CDAWeb data rewrite rule in `speasy/config/__init__.py` to use an HTTPS endpoint (`https://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/`) instead of HTTP.
* Updated the proxy server example in `speasy/core/proxy/__init__.py` to use HTTPS (`https://sciqlop.lpp.polytechnique.fr/cache`) instead of HTTP.