### PR TITLE
Adds a function to drop all cache entries for a specific cached function

### DIFF
--- a/speasy/core/cache/__init__.py
+++ b/speasy/core/cache/__init__.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 import re
 from .cache import Cache, CacheItem
 from ._function_cache import CacheCall
@@ -79,16 +79,15 @@ def get_item(key, default_value=None):
     return _cache.get(key, default_value)
 
 
-def drop_matching_entries(pattern: Union[str, re.Pattern]):
+def drop_matching_entries(pattern: Union[str, re.Pattern], cache_instance: Optional[Cache] = None):
     """Drop all cache entries that match a given pattern
 
     Parameters
     ----------
     pattern : str or re.Pattern
         The pattern to match cache keys against
+    cache_instance : Cache, optional
+        The cache instance to operate on, by default None (uses the default global cache)
     """
-    if isinstance(pattern, str):
-        pattern = re.compile(pattern)
-    for key in filter(pattern.match, _cache.keys()):
-        log.debug(f"Dropping cache entry {key}")
-        _cache.drop(key)
+    cache_instance = cache_instance or _cache
+    cache_instance.drop_matching_entries(pattern)

--- a/speasy/core/cache/cache.py
+++ b/speasy/core/cache/cache.py
@@ -5,8 +5,12 @@ import diskcache as dc
 from .version import str_to_version, version_to_str, Version
 from speasy.config import cache as cache_cfg
 from contextlib import ExitStack, contextmanager
+import re
+import logging
 
 cache_version = str_to_version("3.0")
+
+log = logging.getLogger(__name__)
 
 
 class CacheItem:
@@ -103,6 +107,20 @@ class Cache:
 
     def drop(self, key):
         self._data.delete(key)
+
+    def drop_matching_entries(self, pattern: Union[str, re.Pattern]):
+        """Drop all cache entries that match a given pattern
+
+        Parameters
+        ----------
+        pattern : str or re.Pattern
+            The pattern to match cache keys against
+        """
+        if isinstance(pattern, str):
+            pattern = re.compile(pattern)
+        for key in filter(pattern.match, self.keys()):
+            log.debug(f"Dropping cache entry {key}")
+            self.drop(key)
 
     @contextmanager
     def transact(self):


### PR DESCRIPTION
This pull request introduces improvements to the cache management system, focusing on enabling more flexible cache entry removal and enhancing the function cache decorator. The main changes include adding support for dropping cache entries by pattern on specific cache instances, exposing cache internals for testing, and providing a mechanism to clear all cache entries associated with a decorated function. These updates improve testability and extensibility for cache operations.

**Cache entry management enhancements:**

* Added a `drop_matching_entries` method to the `Cache` class, allowing removal of cache entries matching a regex pattern, and improved logging for dropped entries.
* Updated the `drop_matching_entries` function in `speasy/core/cache/__init__.py` to accept an optional `cache_instance` argument, enabling targeted cache operations instead of always using the global cache.

**Function cache decorator improvements:**

* Extended the `CacheCall` class to support a `leak_cache` option, which exposes the underlying cache instance via the decorated function for testing and introspection. Also added a `drop_entries` method to clear all cache entries related to a specific decorated function. [[1]](diffhunk://#diff-22efab015c43621b3f3216b8d8691995dd4a18348e079245e760a3d04292fcb0L19-R28) [[2]](diffhunk://#diff-22efab015c43621b3f3216b8d8691995dd4a18348e079245e760a3d04292fcb0R45-R61) [[3]](diffhunk://#diff-22efab015c43621b3f3216b8d8691995dd4a18348e079245e760a3d04292fcb0R71-R73)

**Testing enhancements:**

* Added unit tests to verify the ability to clear cache entries associated with a decorated function, leveraging the new `leak_cache` and `drop_entries` features.

**Type hint improvements:**

* Updated type hints to use `Optional` in relevant modules for better clarity and type safety. [[1]](diffhunk://#diff-02f4a7dac16b4fe91f6cd55b93538ef13a667bc73d6bf6060ca0c1c61c5c4ad2L1-R1) [[2]](diffhunk://#diff-22efab015c43621b3f3216b8d8691995dd4a18348e079245e760a3d04292fcb0L5-R5)