### PR TITLE
Make Speasy init a bit more robust

### DIFF
--- a/speasy/data_providers/__init__.py
+++ b/speasy/data_providers/__init__.py
@@ -3,3 +3,4 @@ from .cda import CdaWebservice
 from .csa import CsaWebservice
 from .generic_archive import GenericArchive
 from .ssc import SscWebservice
+from .uiowa_eph_tool import UiowaEphTool


### PR DESCRIPTION
This pull request refactors the provider initialization logic in `request_dispatch.py` to make it more robust and maintainable. The main change is the introduction of a generic, reusable provider initialization function that reduces code duplication and improves error handling. Additionally, the `UiowaEphTool` provider is now properly imported and supported.

**Provider initialization refactor:**

* Introduced a generic `_safe_init_provider` function to handle the initialization of all providers, consolidating repeated logic and improving error handling with logging and traceback on failure. (`speasy/core/requests_scheduling/request_dispatch.py`)
* Replaced individual provider initialization functions (`init_amda`, `init_csa`, `init_cdaweb`, `init_sscweb`, `init_archive`, `init_uiowaephtool`) with calls to `_safe_init_provider`, reducing code duplication and ensuring consistent behavior. (`speasy/core/requests_scheduling/request_dispatch.py`)

**Provider support updates:**

* Added `UiowaEphTool` to the list of imported providers, ensuring it can be initialized and used like the others. (`speasy/data_providers/__init__.py`, `speasy/core/requests_scheduling/request_dispatch.py`) [[1]](diffhunk://#diff-0e5ce218bdac02e4dff5741983965ee3958aa93add668fc06c04785c9c10df7cR6) [[2]](diffhunk://#diff-5aa38a31965b762909190b5464c52b1f5134f217804442f2b7e5f206fe25d85dL14-R18)

**Error handling improvements:**

* Enhanced logging for provider initialization failures by including the traceback, making debugging easier. (`speasy/core/requests_scheduling/request_dispatch.py`)