### PR TITLE
Ensures SSCWeb variables have a name

### DIFF
--- a/speasy/data_providers/ssc/__init__.py
+++ b/speasy/data_providers/ssc/__init__.py
@@ -65,6 +65,7 @@ def parse_trajectory(trajectory: str) -> Optional[SpeasyVariable]:
         return SpeasyVariable(
             axes=[VariableTimeAxis(values=time_axis)],
             values=DataContainer(values,
+                                 name='Position',
                                  meta={'CoordinateSystem': coordinates.find('CoordinateSystem').text.upper(),
                                        'UNITS': 'km'}),
             columns=['X', 'Y', 'Z']


### PR DESCRIPTION
Fixes #265 :

```Python

❯ PYTHONPATH=. python -m jupyter_console
Jupyter console 6.6.3

Python 3.13.11 (main, Dec  5 2025, 00:00:00) [GCC 15.2.1 20251111 (Red Hat 15.2.1-4)]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.37.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import speasy as spz

In [2]: from speasy.core.codecs import get_codec

In [3]: from spacepy import pycdf

In [4]: cdf = get_codec("cdf")

In [5]: result = spz.get_data('sscweb/ace', "2018-01-01", "2018-01-02",
   ...:                                    disable_cache=True,
   ...:                                    disable_proxy=True)

In [6]: cdf.save_variables([result], "/home/jeandet/Downloads/ace_fix.cdf")
Out[6]: True

In [7]: pycdf.CDF("/home/jeandet/Downloads/ace_fix.cdf")
Out[7]: 
<CDF:
Position: CDF_DOUBLE [120, 3]
time: CDF_TIME_TT2000 [120]
>
```