### PR TITLE
3DView provider: Use spz_uid to call get_trajectory

### DIFF
--- a/speasy/data_providers/cdpp3dview/__init__.py
+++ b/speasy/data_providers/cdpp3dview/__init__.py
@@ -177,7 +177,7 @@ class Cdpp3dViewWebservice(DataProvider):
         format: str = "cdf",
         **kwargs,
     ):
-        body = self._to_parameter_index(product).spz_name()
+        body = self._to_parameter_index(product).spz_uid()
 
         date_format = "%Y-%m-%dT%H:%M:%S"
         start_date = start_time.strftime(date_format)

--- a/tests/test_cdpp3dview.py
+++ b/tests/test_cdpp3dview.py
@@ -87,6 +87,11 @@ SOME_PRODUCTS = [
         "start_time": datetime(2000, 8, 22, 0, 18, 30, tzinfo=timezone.utc),
         "stop_time": datetime(2000, 8, 23, 0, 0, 30, tzinfo=timezone.utc),
     },
+    {
+        "product": "Swarm-A",
+        "start_time": datetime(2020, 8, 22, 0, 18, 30, tzinfo=timezone.utc),
+        "stop_time": datetime(2020, 8, 23, 0, 0, 30, tzinfo=timezone.utc),
+    }
 
 ]
 


### PR DESCRIPTION
The call to "get_trajectory" from the 3DView web service is made using the "body" identifier retrieved via the "spz_name" method of the parameter index.

However, the name is constructed from the body after being processed by the "fix_name" function, which replaces certain special characters, such as "-" with "_".

Thus, when attempting to retrieve the trajectories of "Swarm-A", the web service call is as follows:
https://3dview.irap.omp.eu/webresources//get_trajectory?body=Swarm_A&frame=J2000&start=2020-01-01T00:00:00&stop=2020-01-01T01:00:00&sampling=600&format=cdf

However, "Swarm_A" does not correspond to a body recognized by 3DView. The call should instead be made using "Swarm-A" (i.e., the body UID):
https://3dview.irap.omp.eu/webresources//get_trajectory?body=Swarm-A&frame=J2000&start=2020-01-01T00:00:00&stop=2020-01-01T01:00:00&sampling=600&format=cdf