### PR TITLE
Fix generic_archive follow-ups from #308, and let YAML meta patch get_data() results

### DIFF
--- a/docs/user/direct_archive/direct_archive.rst
+++ b/docs/user/direct_archive/direct_archive.rst
@@ -118,6 +118,22 @@ Or, if the data files are in a format other than CDF (e.g. NetCDF), point to a m
     It is deprecated but remains supported.
     Prefer ``master_file`` + ``codec`` for new entries.
 
+A master file's own metadata can be patched too — add a ``meta`` block alongside ``master_file``
+just like the inline format, controlled by the same ``meta_priority``:
+
+.. code-block:: YAML
+
+    my_nc_dataset:
+      inventory_path: my_data/MISSION/INSTRUMENT
+      master_file: https://my_server.net/masters/dataset_master.nc
+      codec: nc
+      meta:
+        Mission_group: MISSION       # the master doesn't have this: always added
+        Data_type: corrected-l2      # the master does have this: only wins with meta_priority: yaml
+      meta_priority: yaml
+      split_rule: regular
+      url_pattern: https://my_server.net/data/{Y}/{M:02d}/data_{Y}{M:02d}{D:02d}.nc
+
 **Step 3: Restart Python and use it**
 
 After saving the YAML file, restart your Python session (the inventory is built at import time):
@@ -149,13 +165,15 @@ YAML field reference
        (e.g. ``my_data/THEMIS/THA`` → ``archive.my_data.THEMIS.THA``).
    * - **meta**
      - Dataset-level metadata (e.g. ``Mission_group``, ``Data_type``). Required together with
-       **variables**. Ignored when a master file is used, since the metadata then comes from the master.
-       Only affects the inventory browser by default — see **meta_priority** to also patch it onto
+       **variables**; optional alongside **master_file**/**master_cdf**, where it patches onto the
+       metadata extracted from the master (see **meta_priority** for which side wins a clash).
+       Only affects the inventory browser by default — **meta_priority** also patches it onto
        ``get_data()`` results.
    * - **meta_priority**
-     - ``file`` (default) or ``yaml``. Controls whether **meta** (dataset- and variable-level) patches
-       onto the ``SpeasyVariable`` returned by ``get_data()``, and which side wins when both the file
-       and the YAML declare the same field. Either way, fields only present in YAML always come through.
+     - ``file`` (default) or ``yaml``. The single knob resolving every YAML-vs-file metadata clash
+       in this dataset: **meta** vs. the master's own metadata at inventory-build time, and the
+       built inventory metadata vs. the real data file's own attributes inside every ``get_data()``
+       call. Either way, fields declared only in YAML always come through.
    * - **variables**
      - Inline description of the dataset's variables, as a mapping of variable name to a ``meta`` block.
        Use this when you want to avoid any network access at inventory build time. Both a dataset-level

--- a/docs/user/direct_archive/direct_archive.rst
+++ b/docs/user/direct_archive/direct_archive.rst
@@ -91,6 +91,17 @@ carries its own ``meta`` block, alongside a dataset-level one:
     codec skips the whole dataset with a warning at import time, rather than failing inside every
     subsequent ``get_data()`` call.
 
+.. important::
+    ``get_data()`` builds its result from the actual data file's own attributes, not from ``meta``
+    above — the ``UNITS``/``CATDESC`` you type here only show up when *browsing* the inventory
+    (``spz.inventories.data_tree...``) unless you also set ``meta_priority``, which patches this
+    ``meta`` onto every ``get_data()`` result too:
+
+    .. code-block:: YAML
+
+        meta_priority: file  # default: YAML meta only fills fields the file doesn't have
+        meta_priority: yaml  # YAML meta overrides the file's own value on a clash
+
 Or, if the data files are in a format other than CDF (e.g. NetCDF), point to a master file and specify the codec:
 
 .. code-block:: YAML
@@ -139,6 +150,12 @@ YAML field reference
    * - **meta**
      - Dataset-level metadata (e.g. ``Mission_group``, ``Data_type``). Required together with
        **variables**. Ignored when a master file is used, since the metadata then comes from the master.
+       Only affects the inventory browser by default — see **meta_priority** to also patch it onto
+       ``get_data()`` results.
+   * - **meta_priority**
+     - ``file`` (default) or ``yaml``. Controls whether **meta** (dataset- and variable-level) patches
+       onto the ``SpeasyVariable`` returned by ``get_data()``, and which side wins when both the file
+       and the YAML declare the same field. Either way, fields only present in YAML always come through.
    * - **variables**
      - Inline description of the dataset's variables, as a mapping of variable name to a ``meta`` block.
        Use this when you want to avoid any network access at inventory build time. Both a dataset-level

--- a/docs/user/direct_archive/direct_archive.rst
+++ b/docs/user/direct_archive/direct_archive.rst
@@ -75,6 +75,7 @@ carries its own ``meta`` block, alongside a dataset-level one:
           meta:
             UNITS: nT
             CATDESC: B along Y
+      codec: nc
       split_rule: regular
       url_pattern: https://my_server.net/data/{Y}/{M:02d}/data_{Y}{M:02d}{D:02d}.nc
 
@@ -82,6 +83,13 @@ carries its own ``meta`` block, alongside a dataset-level one:
     A bare list of names (``variables: [Bx, By]``) is **not** supported: the dataset is skipped and a
     warning is emitted in the log. Both the dataset-level ``meta`` and a ``meta`` for every variable
     are required.
+
+.. note::
+    ``codec`` here has nothing to do with discovering variables (they're already given) — it only
+    tells Speasy how to decode the actual data files at fetch time. It defaults to ``cdf`` if omitted,
+    so set it explicitly whenever ``url_pattern`` doesn't point to CDF files, as above. An unrecognized
+    codec skips the whole dataset with a warning at import time, rather than failing inside every
+    subsequent ``get_data()`` call.
 
 Or, if the data files are in a format other than CDF (e.g. NetCDF), point to a master file and specify the codec:
 
@@ -139,8 +147,10 @@ YAML field reference
      - URL or local path to a master file in any supported format. Speasy opens it once with the
        specified codec to discover the variable names. Replaces ``master_cdf`` for non-CDF formats.
    * - **codec**
-     - Codec identifier to use with ``master_file``. Accepts a file extension (``cdf``, ``nc``) or a
-       MIME type (``application/x-cdf``). Required when ``master_file`` is set.
+     - Codec identifier used both to discover variables from ``master_file`` and, for any dataset
+       (``master_file`` or ``variables``), to decode the actual data files at fetch time. Accepts a
+       file extension (``cdf``, ``nc``) or a MIME type (``application/x-cdf``). Optional, defaults to
+       ``cdf``; an unrecognized value skips the whole dataset with a warning at import time.
    * - **master_cdf** *(deprecated)*
      - URL or local path to a CDF master file. Speasy reads it once to discover which variables the
        dataset contains. Prefer ``master_file`` + ``codec: cdf`` for new entries.

--- a/speasy/data_providers/generic_archive/__init__.py
+++ b/speasy/data_providers/generic_archive/__init__.py
@@ -66,12 +66,19 @@ def _public_meta(node: SpeasyIndex) -> dict:
             if not k.startswith('__spz_') and k != 'spz_ga_cfg' and not hasattr(v, 'spz_name')}
 
 
-def _patch_meta(result: SpeasyVariable, inventory_meta: dict, priority: str) -> None:
+def _merge_meta(file_meta: dict, yaml_meta: dict, priority: str) -> dict:
+    # same 'meta_priority' knob resolves file-vs-YAML metadata everywhere in the pipeline:
+    # here at inventory-build time (master-extracted vs YAML-declared), and again in
+    # _get_data() (freshly-read file vs whatever ended up on the built ParameterIndex)
     if priority == 'yaml':
-        result.meta.update(inventory_meta)
-    else:
-        for key, value in inventory_meta.items():
-            result.meta.setdefault(key, value)
+        return {**file_meta, **yaml_meta}
+    return {**yaml_meta, **file_meta}
+
+
+def _patch_meta(result: SpeasyVariable, inventory_meta: dict, priority: str) -> None:
+    merged = _merge_meta(result.meta, inventory_meta, priority)
+    result.meta.clear()
+    result.meta.update(merged)
 
 
 def _dataset_from_variables(name, path, entry_meta, variables, codec_id='', dataset_meta=None):
@@ -95,9 +102,9 @@ def _dataset_from_variables(name, path, entry_meta, variables, codec_id='', data
                               meta={**dataset_meta, **entry_meta})
 
 
-def _dataset_from_master(name, path, entry_meta, master_file, codec_id):
+def _dataset_from_master(name, path, entry_meta, master_file, codec_id, dataset_meta=None, meta_priority='file'):
     # All strings for a codec id (extension, mime type, class name) resolve to the same instance in
-    # the registry, so we test the codec object instead of a string 
+    # the registry, so we test the codec object instead of a string
     codec = get_codec(codec_id or 'cdf')  # legacy master_cdf entries carry no codec
     if codec is None:
         log.warning(f"Unknown codec '{codec_id}' for dataset {name}, skipping")
@@ -107,10 +114,11 @@ def _dataset_from_master(name, path, entry_meta, master_file, codec_id):
                                      params_uid_format=f"{path}/{{var_name}}",
                                      params_meta=entry_meta)
         if result:
-            parameters, dataset_meta = result
+            parameters, master_meta = result
+            meta = _merge_meta(master_meta, dataset_meta or {}, meta_priority)
             return make_dataset_index(name=name, provider='archive', uid=path,
                                       parameters=parameters,
-                                      meta={**dataset_meta, **entry_meta})
+                                      meta={**meta, **entry_meta})
         return None
     variables = codec.list_variables(master_file)  # non-ISTP codecs: fall back to names only
     if variables is None:  # codec does not implement list_variables, it cannot describe a master
@@ -118,8 +126,9 @@ def _dataset_from_master(name, path, entry_meta, master_file, codec_id):
         return None
     parameters = [ParameterIndex(name=var, provider='archive', uid=f"{path}/{var}")
                   for var in variables]
+    meta = _merge_meta({}, dataset_meta or {}, meta_priority)
     return make_dataset_index(name=name, provider='archive', uid=path,
-                              parameters=parameters, meta=entry_meta)
+                              parameters=parameters, meta={**meta, **entry_meta})
 
 
 def _load_inventory_entry(name, entry, root: SpeasyIndex):
@@ -133,7 +142,9 @@ def _load_inventory_entry(name, entry, root: SpeasyIndex):
                                           codec_id=entry.get('codec', ''), dataset_meta=entry.get('meta'))
     elif master_file and (is_local_file(master_file) or _is_reachable(master_file)):
         dataset = _dataset_from_master(name, path, entry_meta,
-                                       master_file, entry.get('codec', ''))
+                                       master_file, entry.get('codec', ''),
+                                       dataset_meta=entry.get('meta'),
+                                       meta_priority=entry.get('meta_priority', 'file'))
     else:
         dataset = None
         log.warning(f"No reachable master for dataset {name}, skipping")

--- a/speasy/data_providers/generic_archive/__init__.py
+++ b/speasy/data_providers/generic_archive/__init__.py
@@ -61,6 +61,19 @@ def _is_reachable(url: str) -> bool:
     return _is_up(host, port)
 
 
+def _public_meta(node: SpeasyIndex) -> dict:
+    return {k: v for k, v in node.__dict__.items()
+            if not k.startswith('__spz_') and k != 'spz_ga_cfg' and not hasattr(v, 'spz_name')}
+
+
+def _patch_meta(result: SpeasyVariable, inventory_meta: dict, priority: str) -> None:
+    if priority == 'yaml':
+        result.meta.update(inventory_meta)
+    else:
+        for key, value in inventory_meta.items():
+            result.meta.setdefault(key, value)
+
+
 def _dataset_from_variables(name, path, entry_meta, variables, codec_id='', dataset_meta=None):
     valid = (
         dataset_meta
@@ -177,10 +190,14 @@ class GenericArchive(DataProvider):
         Optional[
             SpeasyVariable]:
         ga_cfg: dict = dict(getattr(product, 'spz_ga_cfg'))  # copy: spz_ga_cfg is shared across the dataset and its params
+        meta_priority = ga_cfg.pop('meta_priority', 'file')
         ga_cfg.pop('inventory_path', None)
         ga_cfg.pop('master_cdf', None)
         ga_cfg.pop('master_file', None)
         ga_cfg.pop('meta', None)
         ga_cfg.pop('variables', None)
-        return get_product(**ga_cfg,
-                           variable=product.spz_name(), start_time=start_time, stop_time=stop_time, **kwargs)
+        result = get_product(**ga_cfg,
+                             variable=product.spz_name(), start_time=start_time, stop_time=stop_time, **kwargs)
+        if result is not None:
+            _patch_meta(result, _public_meta(product), meta_priority)
+        return result

--- a/speasy/data_providers/generic_archive/__init__.py
+++ b/speasy/data_providers/generic_archive/__init__.py
@@ -61,7 +61,7 @@ def _is_reachable(url: str) -> bool:
     return _is_up(host, port)
 
 
-def _dataset_from_variables(name, path, entry_meta, variables, dataset_meta=None):
+def _dataset_from_variables(name, path, entry_meta, variables, codec_id='', dataset_meta=None):
     valid = (
         dataset_meta
         and isinstance(variables, dict) and variables
@@ -70,6 +70,9 @@ def _dataset_from_variables(name, path, entry_meta, variables, dataset_meta=None
     if not valid:
         log.warning(f"Dataset {name}: inline format requires a dataset 'meta' and a 'meta' "
                     f"for each variable, skipping")
+        return None
+    if get_codec(codec_id or 'cdf') is None:  # get_data() resolves this same key at fetch time
+        log.warning(f"Unknown codec '{codec_id}' for dataset {name}, skipping")
         return None
     parameters = [ParameterIndex(name=var, provider='archive', uid=f"{path}/{var}",
                                  meta={**info['meta'], **entry_meta})
@@ -114,7 +117,7 @@ def _load_inventory_entry(name, entry, root: SpeasyIndex):
     master_file = entry.get('master_file') or entry.get('master_cdf') or None
     if 'variables' in entry:
         dataset = _dataset_from_variables(name, path, entry_meta, entry['variables'],
-                                          dataset_meta=entry.get('meta'))
+                                          codec_id=entry.get('codec', ''), dataset_meta=entry.get('meta'))
     elif master_file and (is_local_file(master_file) or _is_reachable(master_file)):
         dataset = _dataset_from_master(name, path, entry_meta,
                                        master_file, entry.get('codec', ''))

--- a/speasy/data_providers/generic_archive/__init__.py
+++ b/speasy/data_providers/generic_archive/__init__.py
@@ -180,5 +180,7 @@ class GenericArchive(DataProvider):
         ga_cfg.pop('inventory_path', None)
         ga_cfg.pop('master_cdf', None)
         ga_cfg.pop('master_file', None)
+        ga_cfg.pop('meta', None)
+        ga_cfg.pop('variables', None)
         return get_product(**ga_cfg,
                            variable=product.spz_name(), start_time=start_time, stop_time=stop_time, **kwargs)

--- a/speasy/data_providers/generic_archive/__init__.py
+++ b/speasy/data_providers/generic_archive/__init__.py
@@ -72,7 +72,7 @@ def _dataset_from_variables(name, path, entry_meta, variables, dataset_meta=None
                     f"for each variable, skipping")
         return None
     parameters = [ParameterIndex(name=var, provider='archive', uid=f"{path}/{var}",
-                                 meta=info['meta'])
+                                 meta={**info['meta'], **entry_meta})
                   for var, info in variables.items()]
     return make_dataset_index(name=name, provider='archive', uid=path,
                               parameters=parameters,

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -234,6 +234,53 @@ class DirectArchiveDownloader(unittest.TestCase):
         self.assertEqual(len(result), len(oracle))
         np.testing.assert_array_equal(result.values.ravel(), oracle.ravel())
 
+    def _get_data_for_patch_meta_test(self, extra_entry_keys=None):
+        # Shared setup for the meta-patching tests below: an inline 'variables:' dataset whose
+        # hand-typed meta both overlaps with a real file attribute (UNITS) and adds one the file
+        # doesn't have (Custom_field), so we can tell file-derived and YAML-derived meta apart.
+        import tempfile
+        import yaml
+        from speasy.core.inventory.indexes import SpeasyIndex
+        from speasy.data_providers.generic_archive import load_inventory_file, GenericArchive
+
+        cdf = f"{__HERE__}/resources/ac_k2_mfi_20220101_v03.cdf"
+        entry = {
+            "DS_patch": {
+                "inventory_path": "archive/test",
+                "meta": {"Mission_group": "ACE"},
+                "variables": {"Magnitude": {"meta": {"UNITS": "made_up_unit", "Custom_field": "custom_value"}}},
+                "url_pattern": cdf,
+                "split_rule": "regular",
+                **(extra_entry_keys or {}),
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            yaml.safe_dump(entry, f)
+            yaml_path = f.name
+        try:
+            root = SpeasyIndex(name="root", provider="archive", uid="root")
+            load_inventory_file(yaml_path, root)
+            param = root.archive.test.DS_patch.Magnitude
+            provider = object.__new__(GenericArchive)
+            return provider._get_data(product=param, start_time="2022-01-01", stop_time="2022-01-01T23:59")
+        finally:
+            os.unlink(yaml_path)
+
+    def test_get_data_patches_meta_missing_from_file_by_default(self):
+        # By default (no 'meta_priority' key), YAML-only fields not present in the real file
+        # (Custom_field) should still reach the returned SpeasyVariable -- but fields the file
+        # already provides (UNITS) keep the file's own value. This test fails before the fix:
+        # today _get_data() never looks at the inventory's own meta at all.
+        result = self._get_data_for_patch_meta_test()
+        self.assertEqual(result.meta.get("Custom_field"), "custom_value")
+        self.assertEqual(result.meta.get("UNITS"), "nT")  # the file's real value, not the YAML one
+
+    def test_get_data_meta_priority_yaml_overrides_file(self):
+        # 'meta_priority: yaml' makes YAML-declared fields win over the file's own attributes.
+        result = self._get_data_for_patch_meta_test(extra_entry_keys={"meta_priority": "yaml"})
+        self.assertEqual(result.meta.get("Custom_field"), "custom_value")
+        self.assertEqual(result.meta.get("UNITS"), "made_up_unit")
+
     def test_get_product_with_custom_loader(self):
         v = get_product(
             url_pattern="https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3/1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v05_11.cdf",

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -182,6 +182,58 @@ class DirectArchiveDownloader(unittest.TestCase):
         self.assertEqual(len(result), len(oracle))              # 49 points, nothing lost
         np.testing.assert_array_equal(result.values.ravel(), oracle.ravel())
 
+    def test_get_data_end_to_end_inline_variables_values(self):
+        # End-to-end through the inline 'variables:' format (metadata comes from the YAML
+        # itself, no master file): inventory build + data retrieval, asserting values match
+        # a native pyistp read of the same file.
+        #
+        # 'meta' and 'variables' are archive-config-only keys with no place in get_product()'s
+        # signature; spz_ga_cfg carries the whole YAML entry unfiltered, so both leak all the
+        # way to _read_cdf(url, variable, master_cdf_url=None) which has no **kwargs to absorb
+        # them, raising TypeError. This test fails before the fix.
+        import tempfile
+        import yaml
+        import pyistp
+        from speasy.core.inventory.indexes import SpeasyIndex
+        from speasy.data_providers.generic_archive import load_inventory_file, GenericArchive
+
+        cdf = f"{__HERE__}/resources/ac_k2_mfi_20220101_v03.cdf"
+        entry = {
+            "DS_inline": {
+                "inventory_path": "archive/test",
+                "meta": {"Mission_group": "ACE"},
+                "variables": {"Magnitude": {"meta": {"UNITS": "nT"}}},
+                "url_pattern": cdf,
+                "split_rule": "regular",
+            }
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            yaml.safe_dump(entry, f)
+            yaml_path = f.name
+        try:
+            root = SpeasyIndex(name="root", provider="archive", uid="root")
+            load_inventory_file(yaml_path, root)
+
+            dataset = root.archive.test.DS_inline
+            param = dataset.Magnitude
+
+            provider = object.__new__(GenericArchive)
+            # url_pattern has no {Y}/{M}/{D} placeholders, so it resolves to the same fixed
+            # file regardless of date; keep the range inside a single default "daily" split
+            # period so file_reader is only called once (a second, identical fetch would
+            # only be pruned by merge()'s "covered by previous" dedup, which isn't what this
+            # test is about).
+            result = provider._get_data(product=param,
+                                        start_time="2022-01-01", stop_time="2022-01-01T23:59")
+        finally:
+            os.unlink(yaml_path)
+
+        oracle = pyistp.load(file=cdf).data_variable("Magnitude").values
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), len(oracle))
+        np.testing.assert_array_equal(result.values.ravel(), oracle.ravel())
+
     def test_get_product_with_custom_loader(self):
         v = get_product(
             url_pattern="https://cdaweb.gsfc.nasa.gov/pub/data/arase/pwe/hfa/l3/1min/{Y}/erg_pwe_hfa_l3_1min_{Y}{M:02d}{D:02d}_v05_11.cdf",

--- a/tests/test_direct_archive_inventory.py
+++ b/tests/test_direct_archive_inventory.py
@@ -59,6 +59,20 @@ my_dataset_meta:
   url_pattern: https://example.org/{Y}/data.cdf
 """
 
+_VARIABLES_WITH_UNKNOWN_CODEC_YAML = """\
+bogus_codec_dataset:
+  inventory_path: cda/test
+  meta:
+    Mission_group: ERG
+  variables:
+    Bgse:
+      meta:
+        UNITS: nT
+  codec: not_a_real_codec
+  split_rule: regular
+  url_pattern: https://example.org/{Y}/data.cdf
+"""
+
 _MASTER_FILE_NC_YAML = f"""\
 ac_mfi_nc_dataset:
   inventory_path: cda/test
@@ -288,6 +302,14 @@ class TestLoadInventoryFile(unittest.TestCase):
         self.assertIsNotNone(ga_cfg)
         self.assertEqual(ga_cfg.get('url_pattern'), 'https://example.org/{Y}/data.cdf')
         self.assertEqual(ga_cfg.get('split_rule'), 'regular')
+
+    def test_skips_inline_variables_dataset_with_unknown_codec(self):
+        # unlike master_file entries, inline 'variables:' entries never validated 'codec' at all:
+        # a typo would sail through inventory building and only blow up deep inside get_data(),
+        # instead of being skipped up front like an unknown codec on the master_file path.
+        root = _load_yaml_doc(_VARIABLES_WITH_UNKNOWN_CODEC_YAML)
+        test_node = root.__dict__['cda'].__dict__['test']
+        self.assertNotIn('bogus_codec_dataset', test_node.__dict__)
 
     def test_loads_dataset_with_master_file_nc(self):
         root = _make_root()

--- a/tests/test_direct_archive_inventory.py
+++ b/tests/test_direct_archive_inventory.py
@@ -279,6 +279,16 @@ class TestLoadInventoryFile(unittest.TestCase):
         var_names = {v.spz_name() for v in dataset.__dict__.values() if hasattr(v, 'spz_name')}
         self.assertEqual(var_names, {'Bgse', 'Bgsm'})
 
+    def test_variable_from_inline_yaml_carries_archive_cfg_for_get_data(self):
+        # GenericArchive._get_data() reads spz_ga_cfg off the ParameterIndex, not the DatasetIndex
+        root = _load_yaml_doc(_VARIABLES_WITH_META_YAML)
+        dataset = root.__dict__['cda'].__dict__['test'].__dict__.get('my_dataset_meta')
+        bgse = dataset.__dict__['Bgse']
+        ga_cfg = getattr(bgse, 'spz_ga_cfg', None)
+        self.assertIsNotNone(ga_cfg)
+        self.assertEqual(ga_cfg.get('url_pattern'), 'https://example.org/{Y}/data.cdf')
+        self.assertEqual(ga_cfg.get('split_rule'), 'regular')
+
     def test_loads_dataset_with_master_file_nc(self):
         root = _make_root()
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:

--- a/tests/test_direct_archive_inventory.py
+++ b/tests/test_direct_archive_inventory.py
@@ -91,6 +91,18 @@ ac_mfi_cdf_dataset:
   url_pattern: https://example.org/{{Y}}/data.cdf
 """
 
+_MASTER_FILE_CDF_WITH_META_YAML = f"""\
+ac_mfi_meta_override:
+  inventory_path: cda/test
+  master_file: {__HERE__}/resources/ac_k2_mfi_20220101_v03.cdf
+  codec: cdf
+  meta:
+    Custom_field: custom_value
+    Data_type: yaml_override
+  split_rule: regular
+  url_pattern: https://example.org/{{Y}}/data.cdf
+"""
+
 _MASTER_CDF_LOCAL_YAML = f"""\
 ac_mfi_local_master_cdf:
   inventory_path: cda/test
@@ -380,6 +392,25 @@ class TestLoadInventoryFile(unittest.TestCase):
         var_names = {v.spz_name() for v in dataset.__dict__.values() if hasattr(v, 'spz_name')}
         self.assertIn('Magnitude', var_names)
         self.assertIn('BGSEc', var_names)
+
+    def test_master_file_dataset_meta_fills_gaps_by_default(self):
+        # meta on a master_file entry was completely ignored before the fix: Custom_field
+        # (which the master doesn't have) never made it onto the dataset, and there was no way
+        # to tell -- the master's own Data_type kept its real value either way. This test fails
+        # on the Custom_field assertion before the fix.
+        root = _load_yaml_doc(_MASTER_FILE_CDF_WITH_META_YAML)
+        dataset = root.__dict__['cda'].__dict__['test'].__dict__.get('ac_mfi_meta_override')
+        self.assertIsNotNone(dataset)
+        self.assertEqual(dataset.__dict__.get('Custom_field'), 'custom_value')
+        self.assertEqual(dataset.__dict__.get('Data_type'), 'K2>1-Hr Key Parameter Data')
+
+    def test_master_file_dataset_meta_priority_yaml_overrides_master(self):
+        root = _load_yaml_doc(_MASTER_FILE_CDF_WITH_META_YAML.replace(
+            "codec: cdf", "codec: cdf\n  meta_priority: yaml"))
+        dataset = root.__dict__['cda'].__dict__['test'].__dict__.get('ac_mfi_meta_override')
+        self.assertIsNotNone(dataset)
+        self.assertEqual(dataset.__dict__.get('Custom_field'), 'custom_value')
+        self.assertEqual(dataset.__dict__.get('Data_type'), 'yaml_override')
 
     def test_loads_dataset_with_local_master_cdf_no_codec(self):
         # master_cdf key without codec + local file: must route through the cdf path


### PR DESCRIPTION
## Summary
Bug fixes for the `generic_archive` provider left over from #308, plus two new capabilities found while tracing how metadata flows through it.

- Follow-up to #308: `_dataset_from_variables()` built each `ParameterIndex` with only its own `meta` block, never merging in `entry_meta` (which carries `spz_ga_cfg`). `GenericArchive._get_data()` reads `spz_ga_cfg` off the parameter, so `get_data()` on any parameter from an inline `variables:` YAML dataset raised `AttributeError: 'ParameterIndex' object has no attribute 'spz_ga_cfg'`.
  - Fix mirrors the ISTP branch of `_dataset_from_master`, which already forwards `entry_meta` per-parameter via `params_meta`.
  - Addresses the open review comment: https://github.com/SciQLop/speasy/pull/308#issuecomment-5004427554
- `_dataset_from_variables()` never validated the `codec:` key, unlike `_dataset_from_master`. A typo'd/unsupported codec built the dataset anyway and only surfaced as a confusing crash deep inside `get_product()` on every `get_data()` call, instead of a clear warning at inventory-build time.
  - Fix mirrors `_dataset_from_master`'s existing `get_codec(codec_id or 'cdf')` + warn-and-skip guard.
- `_get_data()` forwards `spz_ga_cfg` (the whole raw YAML entry) to `get_product()` almost unfiltered — it only popped `inventory_path`/`master_cdf`/`master_file`. For inline `variables:` datasets, the archive-config-only `meta` and `variables` keys leaked all the way to `_read_cdf()`, which has no `**kwargs` to absorb them, raising `TypeError`. No test called `get_data()` through the full path for this dataset type before this PR.
  - Fix: pop `meta` and `variables` too, same pattern as the existing pops.
- **New**: neither master-file-extracted nor hand-typed YAML metadata ever reached the `SpeasyVariable` returned by `get_data()` — it's built entirely from the actual data file's own attributes at fetch time, completely independent of the inventory. Verified live: setting `UNITS: made_up_unit` in an inline `variables:` entry, `get_data()` still returned the real file's `UNITS: nT`. Added a `meta_priority` YAML key (`file` default, or `yaml`) so YAML-declared metadata can patch onto `get_data()` results, with either side able to win a conflict — fields only present in YAML always come through either way.
- **New**: extended the same fix to `master_file`/`master_cdf` datasets — a dataset-level `meta` block alongside a master file was silently dropped entirely (not merged, no warning). It now merges with the master-extracted metadata using the same `meta_priority` knob, so one setting resolves YAML-vs-file precedence consistently at both inventory-build time and `get_data()` time.
- Doc fixes: the YAML field reference (added by #308) said `codec` was "required when `master_file` is set" — it isn't, it defaults to `cdf`, same as `master_cdf`. Added the (now-validated) `codec` key to the inline-variables example, whose `url_pattern` points at `.nc` files without it. Documented `meta_priority` for both the inline and master-file cases.

## Test plan
- [x] Test-first for every fix and both new features: added a failing test, confirmed it reproduces the issue on the prior commit, then applied the change
  - `test_variable_from_inline_yaml_carries_archive_cfg_for_get_data`
  - `test_skips_inline_variables_dataset_with_unknown_codec`
  - `test_get_data_end_to_end_inline_variables_values` (builds inventory from an inline `variables:` YAML entry, calls `_get_data()`, checks values against a native pyistp read — same technique as the existing `test_get_data_end_to_end_master_nc_values`)
  - `test_get_data_patches_meta_missing_from_file_by_default` / `test_get_data_meta_priority_yaml_overrides_file`
  - `test_master_file_dataset_meta_fills_gaps_by_default` / `test_master_file_dataset_meta_priority_yaml_overrides_master`
- [x] `PYTHONPATH=. py.test tests/test_direct_archive_inventory.py tests/test_direct_archive_downloader.py` — 49 passed
- [x] `PYTHONPATH=. make doctest` scoped to `user/direct_archive` — 5 passed (remaining suite failures are pre-existing, network-dependent, unrelated docs)
- [x] Rebased onto `upstream/main` after #315 merged (CI speed fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S48g8ZVc2L1ve612BWLLwE