### PR TITLE
Give the rapid-loop unversioned-cache test its own retention margin

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,16 +1,19 @@
 import operator
 import os
 import shutil
+import sys
 import tempfile
 import time
 import unittest
 from concurrent.futures import ThreadPoolExecutor, wait
 from datetime import datetime, timedelta, timezone
+from unittest import mock
 import dateutil.parser as dt_parser
 import numpy as np
 import packaging.version as Version
 from ddt import data, ddt, unpack
 
+import speasy.core.cache.cache as cache_mod
 from speasy.core import epoch_to_datetime64
 from speasy.core.cache import Cache, Cacheable, UnversionedProviderCache, drop_matching_entries, CacheCall
 from speasy.core.cache.version import str_to_version, version_to_str
@@ -55,6 +58,19 @@ class _CacheTest(unittest.TestCase):
             self._make_unversioned_data_cntr += 1
             return data_generator(start_time, stop_time)
         return None
+
+    # Separate from _make_unversioned_data on purpose: that one needs a
+    # sub-second retention so test_get_outdated_from_unversioned_cache's
+    # time.sleep(3.) can trip real staleness without waiting the production
+    # 14-day default. Sharing that thin margin with a rapid, non-sleeping
+    # loop (below) left no headroom for a slow CI iteration to occur without
+    # being mistaken for staleness -- this one gets its own generous margin
+    # instead of being tuned to fit both use cases at once.
+    @UnversionedProviderCache(prefix="", cache_instance=cache, leak_cache=True,
+                              cache_retention=timedelta(minutes=5))
+    def _make_stable_unversioned_data(self, product, start_time, stop_time, if_newer_than=None):
+        self._make_unversioned_data_cntr += 1
+        return data_generator(start_time, stop_time)
 
     def _get_and_check(self, start, stop, data_f):
         var = data_f(f"...{data_f}", start, stop)
@@ -137,8 +153,31 @@ class _CacheTest(unittest.TestCase):
         tend = datetime(2010, 6, 1, 15, 30, tzinfo=timezone.utc)
         self.assertEqual(self._make_unversioned_data_cntr, 0)
         for i in range(10):
-            var = self._make_unversioned_data("test_get_cached_from_unversioned_cache", tstart, tend)
+            var = self._make_stable_unversioned_data("test_get_cached_from_unversioned_cache", tstart, tend)
             self.assertEqual(self._make_unversioned_data_cntr, 1)
+
+    def test_get_cached_from_unversioned_cache_survives_a_slow_iteration(self):
+        # Regression test: a single slow loop iteration (a loaded CI runner
+        # taking over a second to complete one round-trip) must not be
+        # mistaken for real staleness. This drives a virtual clock instead
+        # of relying on a real slow machine, so the bug reproduces on demand.
+        tstart = datetime(2010, 6, 1, 12, 0, tzinfo=timezone.utc)
+        tend = datetime(2010, 6, 1, 15, 30, tzinfo=timezone.utc)
+        virtual_now = [datetime(2026, 1, 1, tzinfo=timezone.utc)]
+
+        class FakeDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return virtual_now[0]
+
+        with mock.patch.object(cache_mod, "datetime", FakeDateTime), \
+             mock.patch.object(sys.modules[__name__], "datetime", FakeDateTime):
+            for i in range(10):
+                if i == 4:
+                    virtual_now[0] += timedelta(seconds=2)
+                self._make_stable_unversioned_data(
+                    "test_get_cached_from_unversioned_cache_survives_a_slow_iteration", tstart, tend)
+                self.assertEqual(self._make_unversioned_data_cntr, 1)
 
     def test_get_outdated_from_unversioned_cache(self):
         tstart = datetime(2010, 6, 1, 12, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- `test_get_cached_from_unversioned_cache` shared `_make_unversioned_data`'s 0.5s `cache_retention` / 1s `if_newer_than` guard with the two sleep-based staleness tests (`test_get_outdated_from_unversioned_cache`, `test_get_data_unversioned_prefer_cache`), which need that thin margin so a real `time.sleep()` can trip staleness without waiting the production 14-day default.
- The rapid, non-sleeping loop needs the opposite: enough headroom that a single slow iteration is never mistaken for staleness. A Windows CI run (#316, job [88388605699](https://github.com/SciQLop/speasy/actions/runs/29745162267/job/88388605699)) hit exactly that — one loop iteration took over a second, tripped the shared margin, and produced a real recompute (`AssertionError: 2 != 1`) that had nothing to do with cache correctness. Root-caused by driving a virtual clock through the real code path: injecting a controlled >1s gap deterministically reproduces the exact failure, and a 0s/0.6s gap never does.
- Adds `_make_stable_unversioned_data` with its own 5-minute retention, used only by the rapid-loop test, so it no longer shares a margin tuned for a different test's needs.
- Adds a regression test that drives that virtual clock to reproduce the failure signature on demand (fails against the old shared margin, passes with the dedicated one), rather than depending on another slow CI run to catch a regression.

## Test plan
- [x] `pytest tests/test_cache.py -k unversioned` — 4 passed
- [x] `pytest tests/test_cache.py` — 288 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S48g8ZVc2L1ve612BWLLwE