### PR TITLE
Serve CDAWeb NetCDF datasets by direct file access, behind a lazy cached probe

### DIFF
--- a/docs/user/cdaweb/cdaweb.rst
+++ b/docs/user/cdaweb/cdaweb.rst
@@ -29,8 +29,18 @@ Specific CDAWeb options
 The CDAWeb module lets you choose the access method among ``BEST``, ``FILE``, and ``API``. The default is ``BEST``.
 
 * ``BEST`` — automatically selects between ``FILE`` and ``API`` for each dataset.
-* ``FILE`` — downloads CDF files directly from the CDAWeb archive.
+* ``FILE`` — downloads data files directly from the CDAWeb archive.
 * ``API`` — retrieves data through the CDAWeb REST API.
+
+.. note::
+    Most CDAWeb datasets are CDF, but 70 are NetCDF. Those can go through ``FILE`` too, on two
+    conditions the container format does not tell: their files must carry the ISTP attributes the
+    NetCDF codec needs (``DEPEND_0``, ``VAR_TYPE``), and CDAWeb's file naming must really describe
+    the archive. Speasy settles it by loading the requested variable from the first file it would
+    download, and remembers the answer for a week. Whatever fails — plain NetCDF, the datasets
+    CDAWeb describes with one sample file name instead of a pattern, the seven published as GIF or
+    MPEG, and every parameter CDAWeb computes itself — keeps going through the REST API. None of
+    the current NetCDF datasets passes, so this mostly opens the door for the ones to come.
 
 .. note::
     ``FILE`` (and therefore ``BEST``, the default) reuses the :doc:`../direct_archive/direct_archive`

--- a/speasy/core/codecs/bundled_codecs/istp/cdf.py
+++ b/speasy/core/codecs/bundled_codecs/istp/cdf.py
@@ -45,14 +45,20 @@ def _convert_attributes_to_variables(variable_name: str, attrs: Mapping, cdf: py
     return clean_attrs
 
 
-def _write_axis(ax: VariableAxis, cdf: pycdfpp.CDF, compress_variables=False) -> bool:
+def _write_axis(ax: VariableAxis, cdf: pycdfpp.CDF, compress_variables=False,
+                time_axis_name: Optional[str] = None) -> bool:
     data_type = None
     if ax.values.dtype == np.dtype("datetime64[ns]"):
         data_type = pycdfpp.DataType.CDF_TIME_TT2000
+    # only the record varying marker, not the whole axis meta: that is how the reader tells a
+    # record varying axis from a fixed one, and without it a grid spanning every dimension comes
+    # back time independent and then matches none of them
+    attributes = {"DEPEND_0": time_axis_name} if time_axis_name is not None and ax.is_time_dependent else None
     cdf.add_variable(
         name=ax.name,
         values=_simplify_shape(ax.values),
         data_type=data_type,
+        attributes=attributes,
         compression=pycdfpp.CompressionType.gzip_compression if compress_variables else pycdfpp.CompressionType.no_compression
     )
     return True
@@ -70,7 +76,7 @@ def _write_variable(v: SpeasyVariable, cdf: pycdfpp.CDF, already_saved_axes: Lis
     for index, ax in enumerate(v.axes):
         a = _already_in_cdf(ax)
         if a is None:
-            _write_axis(ax, cdf, compress_variables)
+            _write_axis(ax, cdf, compress_variables, time_axis_name=v.axes[0].name if index else None)
             depends[f"DEPEND_{index}"] = ax.name
             already_saved_axes.append(ax)
         else:

--- a/speasy/core/codecs/bundled_codecs/istp/netcdf.py
+++ b/speasy/core/codecs/bundled_codecs/istp/netcdf.py
@@ -56,31 +56,49 @@ def _write_time_axis(axis, ds) -> str:
     return dim_name
 
 
-def _write_extra_axis(axis, time_dim_name: str, ds):
-    ax_dim_name = f"dim_{axis.name}"
+def _data_dimensions(v: SpeasyVariable, time_dim_name: str, ds) -> List[str]:
+    """One dimension per dimension of the data, named after the axis describing it when there is one.
+
+    Sizing them from the data rather than from the axes is what lets an axis span several of them.
+    """
+    names = [time_dim_name]
+    for index, size in enumerate(v.values.shape[1:], start=1):
+        name = f"dim_{v.axes[index].name}" if index < len(v.axes) else f"dim_{index}"
+        if name not in ds.dimensions:
+            ds.createDimension(name, size)
+        names.append(name)
+    return names
+
+
+def _axis_dimensions(axis, axis_index: int, data_dims: List[str], data_shape) -> tuple:
+    """The dimensions an axis spans: a coordinate grid covers several, a plain axis covers one."""
+    if axis.values.shape == data_shape:
+        return tuple(data_dims)
+    if axis.values.shape == data_shape[1:]:
+        return tuple(data_dims[1:])
     if axis.is_time_dependent:
-        dims = (time_dim_name, ax_dim_name)
-        size = axis.values.shape[-1]
-    else:
-        dims = (ax_dim_name,)
-        size = axis.values.shape[0]
-    if ax_dim_name not in ds.dimensions:
-        ds.createDimension(ax_dim_name, size)
+        return data_dims[0], data_dims[axis_index]
+    return (data_dims[axis_index],)
+
+
+def _write_extra_axis(axis, dims: tuple, time_dim_name: str, ds):
     if axis.name not in ds.variables:
         var = ds.createVariable(axis.name, _nc_dtype(axis.values), dims)
         var[:] = axis.values
         for k, val in axis.meta.items():
             _try_set_attr(var, k, val)
+        if axis.is_time_dependent:
+            # this is how the reader tells a record varying axis from a fixed one
+            var.DEPEND_0 = time_dim_name
 
 
 def _write_variable_nc(v: SpeasyVariable, ds, written_axes: list):
     time_dim_name = _write_time_axis(v.axes[0], ds)
-    var_dims = [time_dim_name]
-    for ax in v.axes[1:]:
+    var_dims = _data_dimensions(v, time_dim_name, ds)
+    for index, ax in enumerate(v.axes[1:], start=1):
         if ax.name not in written_axes:
-            _write_extra_axis(ax, time_dim_name, ds)
+            _write_extra_axis(ax, _axis_dimensions(ax, index, var_dims, v.values.shape), time_dim_name, ds)
             written_axes.append(ax.name)
-        var_dims.append(f"dim_{ax.name}")
     var = ds.createVariable(v.name, _nc_dtype(v.values), tuple(var_dims))
     var[:] = v.values
     for k, val in v.meta.items():

--- a/speasy/core/direct_archive_downloader/__init__.py
+++ b/speasy/core/direct_archive_downloader/__init__.py
@@ -1,1 +1,1 @@
-from .direct_archive_downloader import get_product
+from .direct_archive_downloader import get_product, first_file

--- a/speasy/core/direct_archive_downloader/direct_archive_downloader.py
+++ b/speasy/core/direct_archive_downloader/direct_archive_downloader.py
@@ -294,6 +294,26 @@ class RegularSplitDirectDownload:
         return None
 
 
+def first_file(url_pattern: str, split_rule: str, start_time: AnyDateTimeType, stop_time: AnyDateTimeType,
+               use_file_list: bool = False, split_frequency: str = "daily", fname_regex: Optional[str] = None,
+               date_format=None, **kwargs) -> Optional[str]:
+    """URL of the first file this archive would read for that range, None when it resolves none.
+
+    Lets a caller look at one real file -- its variable list, its metadata -- without loading data.
+    """
+    if split_rule.lower() == "random":
+        files = RandomSplitDirectDownload.list_files(split_frequency=split_frequency, url_pattern=url_pattern,
+                                                     start_time=start_time, stop_time=stop_time,
+                                                     fname_regex=fname_regex, date_format=date_format)
+        return files[0] if len(files) else None
+    if split_rule.lower() == "regular":
+        urls = (_build_url(url_pattern, date, use_file_list=use_file_list)
+                for date in spilt_range(split_frequency=split_frequency, start_time=start_time,
+                                        stop_time=stop_time))
+        return next(filter(None, urls), None)
+    return None
+
+
 def get_product(url_pattern: str, split_rule: str, variable: str, start_time: AnyDateTimeType,
                 stop_time: AnyDateTimeType, use_file_list: bool = False, file_reader: FileLoaderCallable = _read_cdf,
                 codec: Optional[str] = None,

--- a/speasy/data_providers/cda/__init__.py
+++ b/speasy/data_providers/cda/__init__.py
@@ -16,7 +16,7 @@ from speasy.core import AllowedKwargs, EnsureUTCDateTime
 from speasy.core import http, url_utils
 from speasy.config import cdaweb as cda_cfg
 from speasy.core.codecs import get_codec
-from speasy.core.cache import CACHE_ALLOWED_KWARGS, UnversionedProviderCache
+from speasy.core.cache import CACHE_ALLOWED_KWARGS, CacheCall, UnversionedProviderCache
 from speasy.core.dataprovider import (GET_DATA_ALLOWED_KWARGS, DataProvider,
                                       ParameterRangeCheck)
 from speasy.core.datetime_range import DateTimeRange
@@ -24,7 +24,7 @@ from speasy.core.inventory.indexes import (DatasetIndex, ParameterIndex,
                                            SpeasyIndex)
 from speasy.core.proxy import PROXY_ALLOWED_KWARGS, GetProduct, Proxyfiable
 from speasy.core.requests_scheduling import SplitLargeRequests
-from speasy.core.direct_archive_downloader import get_product as direct_archive_get_product
+from speasy.core.direct_archive_downloader import first_file, get_product as direct_archive_get_product
 from speasy.products.variable import SpeasyVariable
 from ._direct_archive import to_direct_archive_params
 
@@ -41,6 +41,58 @@ def _is_burst_product(product: ParameterIndex or str) -> bool:
 
 def _is_virtual_parameter(product: ParameterIndex) -> bool:
     return product.__dict__.get('VIRTUAL', 'FALSE').upper() == 'TRUE'
+
+
+@CacheCall(cache_retention=timedelta(days=7), is_pure=True)
+def _codec_can_read(file_url: str, codec: str, variable: str) -> bool:
+    """Does the codec really get that variable out of that file?
+
+    Listing the variables is not enough: the ICON_L2-7_IVM-A files list 125 of them and then raise
+    while pyistp walks the axes of half. Only the load answers the question for sure.
+    """
+    try:
+        return get_codec(codec).load_variable(variable, file=file_url) is not None
+    except IOError:
+        raise   # transient, and the caller must not remember it as a verdict on the dataset
+    except Exception as e:
+        log.warning(f"The {codec} codec failed on {file_url}: {type(e).__name__}: {e}")
+        return False
+
+
+def _codec_can_read_archive(archive_params: Dict, variable: str, start_time: datetime,
+                            stop_time: datetime) -> bool:
+    """Can this product be read from the first file the archive serves for that range?
+
+    Asks a real file rather than looking at what get_data() returned: an empty result only means
+    the interval holds no data, while a file the codec can't get the variable out of is a property
+    of the dataset. The retention window gives a dataset that later becomes readable another try.
+    """
+    codec = archive_params['codec']
+    if get_codec(codec) is None:
+        log.warning(f"No {codec} codec available, switching to web service")
+        return False
+    sample_file = first_file(start_time=start_time, stop_time=stop_time, **archive_params)
+    if sample_file is None:
+        return False
+    try:
+        return _codec_can_read(sample_file, codec, variable)
+    except IOError as e:
+        log.warning(f"Failed to probe {sample_file} with the {codec} codec, switching to web service: {e}")
+        return False
+
+
+def _archive_params_for(dataset: DatasetIndex, product_index: ParameterIndex, variable: str,
+                        start_time: datetime, stop_time: datetime) -> Optional[Dict]:
+    """Direct archive parameters when this product can really be served from files, None otherwise."""
+    if _is_virtual_parameter(product_index):
+        return None
+    params = to_direct_archive_params(file_naming=dataset.filenaming, subdivided_by=dataset.subdividedby,
+                                      url=dataset.url)
+    if params is None:
+        return None
+    if 'codec' not in params:
+        return {**params, 'master_cdf_url': dataset.mastercdf}
+    return params if _codec_can_read_archive(params, variable, start_time, stop_time) else None
 
 
 def _large_request_max_duration(product):
@@ -194,19 +246,15 @@ class CdaWebservice(DataProvider):
             product_index = self.flat_inventory.parameters[product]
         else:
             product_index = product
-        archive_params = to_direct_archive_params(file_naming=dataset.filenaming,
-                                                  subdivided_by=dataset.subdividedby,
-                                                  url=dataset.url)
+        archive_params = _archive_params_for(dataset, product_index, variable, start_time, stop_time)
         log.debug(f"Trying to get {product} with direct_archive method, archive_params={archive_params}")
-        if archive_params is not None and not _is_virtual_parameter(product_index):
+        if archive_params is not None:
             return direct_archive_get_product(variable=variable, start_time=start_time, stop_time=stop_time,
-                                              **archive_params,
-                                              master_cdf_url=dataset.mastercdf)
-        else:
-            if not mode_is_best:
-                log.warning(f"Can't get {product} without web service, switching to web service")
-            return self._get_data_with_ws(product=product, start_time=start_time, stop_time=stop_time,
-                                          if_newer_than=if_newer_than, extra_http_headers=extra_http_headers)
+                                              **archive_params)
+        if not mode_is_best:
+            log.warning(f"Can't get {product} without web service, switching to web service")
+        return self._get_data_with_ws(product=product, start_time=start_time, stop_time=stop_time,
+                                      if_newer_than=if_newer_than, extra_http_headers=extra_http_headers)
 
     @AllowedKwargs(
         PROXY_ALLOWED_KWARGS + CACHE_ALLOWED_KWARGS + GET_DATA_ALLOWED_KWARGS + ['if_newer_than', 'method'])

--- a/speasy/data_providers/cda/_direct_archive.py
+++ b/speasy/data_providers/cda/_direct_archive.py
@@ -59,6 +59,16 @@ folder_layouts = {
 }
 
 
+# CDAWeb tells the file format through the file naming: 2850 datasets are CDF, 70 NetCDF and 7 are
+# GIF or MPEG movies Speasy has no codec for. CDF maps to no codec because it is the direct archive
+# downloader's own default reader.
+codec_by_extension = {
+    "cdf": None,
+    "nc": "nc",
+    "nc4": "nc",
+}
+
+
 def _build_date_format(file_naming: str) -> Optional[str]:
     date_format = _date_format_regex.search(file_naming)
     if date_format is None:
@@ -67,8 +77,11 @@ def _build_date_format(file_naming: str) -> Optional[str]:
 
 
 def to_direct_archive_params(file_naming: str, subdivided_by: str, url: str) -> Optional[Dict]:
-    if not file_naming.endswith('.cdf'):
+    extension = file_naming.rsplit('.', 1)[-1].lower()
+    if extension not in codec_by_extension:
         return None
+    codec = codec_by_extension[extension]
+    codec_params = {"codec": codec} if codec else {}
 
     fname_regex = file_naming
 
@@ -87,6 +100,11 @@ def to_direct_archive_params(file_naming: str, subdivided_by: str, url: str) -> 
 
     date_format = _build_date_format(fname_regex)
     if date_format is None:
+        if split_frequency != 'none':
+            # a file name with no date under folders that have one is CDAWeb quoting one real file
+            # instead of a pattern (five datasets do). Taken literally it resolves that same file
+            # for every year asked for, so there is nothing here to describe the archive with.
+            return None
         # nothing in the file name to read a start time from, so the random rule cannot describe
         # this dataset: it is a single fixed file (omni2.cdf, voyager1.cdf...) the regular rule
         # already covers. fname_regex/date_format are left out on purpose, they are random-only
@@ -96,6 +114,7 @@ def to_direct_archive_params(file_naming: str, subdivided_by: str, url: str) -> 
             "split_rule": 'regular',
             "split_frequency": split_frequency,
             "use_file_list": True,
+            **codec_params,
         }
 
     fname_regex = _date_format_regex.sub(r"(?P<start>\\d+t?T?\\d+)", fname_regex, 1)
@@ -108,5 +127,6 @@ def to_direct_archive_params(file_naming: str, subdivided_by: str, url: str) -> 
         "split_frequency": split_frequency,
         "fname_regex": fname_regex,
         "use_file_list": True,
-        "date_format": date_format
+        "date_format": date_format,
+        **codec_params,
     }

--- a/speasy/plotting/__init__.py
+++ b/speasy/plotting/__init__.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 
 import numpy as np
@@ -18,6 +19,23 @@ __backends__ = {
 class PlotType(Enum):
     LINE = 0
     SPECTRO = 1
+
+
+# CDAWeb spells the type first and its options after '>', as in 'spectrogram>y=Center_Scan, z=...'
+# or 'map_image>THUMBSIZE>166>MAP_PROJ>7>SMOOTH>x=latitude,y=longitude'
+_axis_hint_regex = re.compile(r"\b([xy])\s*=\s*([^,>\s]+)")
+
+
+def _display_type(meta) -> str:
+    return meta.get("DISPLAY_TYPE", "").split(">")[0].strip().lower()
+
+
+def _axes_named_by_hint(meta) -> dict:
+    return dict(_axis_hint_regex.findall(meta.get("DISPLAY_TYPE", "")))
+
+
+def _at_time(axis, index: int):
+    return axis.values[index] if axis.is_time_dependent else axis.values
 
 
 @dataclass
@@ -47,9 +65,15 @@ class Plot:
         return values if mask is None else np.where(mask, np.nan, values)
 
     def _infer_plot_type(self):
-        if self.values.meta.get("DISPLAY_TYPE", "").lower() == "spectrogram":
+        if _display_type(self.values.meta) in ("spectrogram", "map_image", "map_movie"):
             return PlotType.SPECTRO
         return PlotType.LINE
+
+    def _coordinate_grid_axes(self):
+        """The grids to spread over, in the order the hint asks for, else in array order."""
+        hint = _axes_named_by_hint(self.values.meta)
+        by_name = {axis.name: axis for axis in self.axes[1:]}
+        return by_name.get(hint.get('x'), self.axes[-1]), by_name.get(hint.get('y'), self.axes[-2])
 
     def line(self, *args, backend=None, **kwargs):
         units = kwargs.pop("units", None) or self.values.unit
@@ -70,31 +94,66 @@ class Plot:
                                                logy=logy, *args,
                                                **kwargs)
 
-    def colormap(self, *args, logy=None, logz=None, backend=None, **kwargs):
-        x_axis_label = kwargs.pop("xaxis_label", None) or self.axes[0].name
-        yaxis_units = kwargs.pop("yaxis_units", None) or self.axes[1].unit
-        yaxis_label = kwargs.pop("yaxis_label", None) or label_from_meta(self.axes[1].meta) or self.axes[1].name
-        zaxis_units = kwargs.pop("zaxis_units", None) or self.values.unit
-        zaxis_label = kwargs.pop("zaxis_label", None) or label_from_meta(self.values.meta) or self.values.name
+    def _spread_over_coordinate_grids(self) -> bool:
+        """Do the extra axes give a coordinate per data cell rather than one value per index?
+
+        That is how CDAWeb ships map products: latitude and longitude cover the whole grid, so
+        there is no axis left to put time on and the colormap shows one time step instead. Every
+        remaining dimension needs one, otherwise there is nothing to spread the field over: PSP's
+        energy grid sits next to a plain look direction axis and is a spectrogram, not a map.
+        """
+        shape = self.values.values.shape
+        return len(shape) > 2 and all(axis.values.shape in (shape, shape[1:]) for axis in self.axes[1:])
+
+    def _grids_arrangement(self, values, time_index: int, logy) -> dict:
+        x_axis, y_axis = self._coordinate_grid_axes()
+        return {
+            "x": _at_time(x_axis, time_index), "y": _at_time(y_axis, time_index), "z": values[time_index],
+            "xaxis_label": label_from_meta(x_axis.meta) or x_axis.name,
+            "yaxis_label": label_from_meta(y_axis.meta) or y_axis.name,
+            "yaxis_units": y_axis.unit,
+            "logy": False if logy is None else logy,
+        }
+
+    def _time_arrangement(self, values, logy) -> dict:
         if logy is None:
             logy = is_log_scale(self.axes[1].meta)
         if logy is None:
             logy = True
+        return {
+            "x": self.axes[0].values, "y": self.axes[1].values.T, "z": values.T,
+            "xaxis_label": self.axes[0].name,
+            "yaxis_label": label_from_meta(self.axes[1].meta) or self.axes[1].name,
+            "yaxis_units": self.axes[1].unit,
+            "logy": logy,
+        }
+
+    def colormap(self, *args, logy=None, logz=None, time_index: int = 0, backend=None, **kwargs):
+        """Colours a 2D field: time against an axis, or one time step over two coordinate grids."""
+        mask_fillval = kwargs.pop("mask_fillval", True)
+        values = self._masked_values() if mask_fillval else self.values.values
+        if self._spread_over_coordinate_grids():
+            arrangement = self._grids_arrangement(values, time_index, logy)
+        elif values.ndim > 2:
+            raise ValueError(
+                f"A colormap needs 2 dimensions, got {values.ndim} dimensions {self.values.shape} "
+                f"and axes describing one value per index. Reduce a dimension first, for instance "
+                f"with numpy.sum(variable, axis=1)."
+            )
+        else:
+            arrangement = self._time_arrangement(values, logy)
+        for key in ("xaxis_label", "yaxis_label", "yaxis_units"):
+            arrangement[key] = kwargs.pop(key, None) or arrangement[key]
+        zaxis_units = kwargs.pop("zaxis_units", None) or self.values.unit
+        zaxis_label = kwargs.pop("zaxis_label", None) or label_from_meta(self.values.meta) or self.values.name
         if logz is None:
             logz = is_log_scale(self.values.meta)
         if logz is None:
             logz = True
-        mask_fillval = kwargs.pop("mask_fillval", True)
-        z = self._masked_values() if mask_fillval else self.values.values
-        return self._get_backend(backend).colormap(x=self.axes[0].values, y=self.axes[1].values.T,
-                                                   z=z.T,
-                                                   xaxis_label=x_axis_label,
-                                                   yaxis_label=yaxis_label,
-                                                   yaxis_units=yaxis_units,
+        return self._get_backend(backend).colormap(*args,
                                                    zaxis_label=zaxis_label,
                                                    zaxis_units=zaxis_units,
-                                                   logy=logy,
-                                                   logz=logz, *args, **kwargs)
+                                                   logz=logz, **arrangement, **kwargs)
 
     def __call__(self, *args, backend=None, **kwargs):
         if self._infer_plot_type() == PlotType.SPECTRO:

--- a/speasy/plotting/mpl_backend/__init__.py
+++ b/speasy/plotting/mpl_backend/__init__.py
@@ -31,18 +31,17 @@ class Plot:
             ax.semilogy()
         return ax
 
-    def colormap(self, x, y, z, xaxis_label=None, yaxis_label=None, yaxis_units=None, zaxis_label=None,
-                 zaxis_units=None, ax=None,
-                 cmap=None, logy=True,
-                 logz=True, vmin=None, vmax=None, *args,
-                 **kwargs):
-        ax = self._get_ax(ax)
+    def _mesh(self, ax, x, y, z, *args, **kwargs):
+        """Cells the instrument was not looking through carry no coordinate at all.
 
-        if yaxis_units is not None and yaxis_label is not None:
-            ax.set_ylabel(f"{yaxis_label} ({yaxis_units})")
-        if xaxis_label is not None:
-            ax.set_xlabel(f"{xaxis_label}")
+        pcolormesh refuses non-finite coordinates outright rather than skipping those cells, while
+        pcolor drops just the quads it cannot place, so a punctured grid goes through pcolor.
+        """
+        if np.all(np.isfinite(x)) and np.all(np.isfinite(y)):
+            return ax.pcolormesh(x, y, z, *args, **kwargs)
+        return ax.pcolor(np.ma.masked_invalid(x), np.ma.masked_invalid(y), z, *args, **kwargs)
 
+    def _norm(self, z, logz, vmin, vmax):
         # A slice that's entirely masked/FILLVAL has no finite value to scale from; fall back to
         # an arbitrary positive bound rather than feeding LogNorm/Normalize a NaN vmin/vmax.
         nonzero = z[np.nonzero(z)]
@@ -50,18 +49,31 @@ class Plot:
             vmin = np.nanmin(nonzero) if np.isfinite(nonzero).any() else 1.0
         if vmax is None:
             vmax = np.nanmax(z) if np.isfinite(z).any() else 1.0
+        if logz:
+            return colors.LogNorm(vmin=vmin, vmax=vmax)
+        return colors.Normalize(vmin=vmin, vmax=vmax)
+
+    def colormap(self, x, y, z, xaxis_label=None, yaxis_label=None, yaxis_units=None, zaxis_label=None,
+                 zaxis_units=None, ax=None,
+                 cmap=None, logy=True,
+                 logz=True, vmin=None, vmax=None, *args,
+                 **kwargs):
+        ax = self._get_ax(ax)
+
+        if yaxis_label is not None:
+            ax.set_ylabel(f"{yaxis_label} ({yaxis_units})" if yaxis_units else yaxis_label)
+        if xaxis_label is not None:
+            ax.set_xlabel(f"{xaxis_label}")
 
         if logy:
             ax.semilogy()
-        if logz:
-            norm = colors.LogNorm(vmin=vmin, vmax=vmax)
-        else:
-            norm = colors.Normalize(vmin=vmin, vmax=vmax)
+        norm = self._norm(z, logz, vmin, vmax)
 
-        ax.tick_params(axis='x', labelrotation=45)
-        cm = ax.pcolormesh(x, y, z,
-                           cmap=cmap or 'plasma',
-                           norm=norm, *args, **kwargs)
+        if np.issubdtype(np.asarray(x).dtype, np.datetime64):   # dates need the room, degrees don't
+            ax.tick_params(axis='x', labelrotation=45)
+        cm = self._mesh(ax, x, y, z,
+                        cmap=cmap or 'plasma',
+                        norm=norm, *args, **kwargs)
         cbar = plt.colorbar(cm, ax=ax)
         if zaxis_units is not None and zaxis_label is not None:
             cbar.set_label(f'{zaxis_label} ({zaxis_units})')

--- a/speasy/products/variable.py
+++ b/speasy/products/variable.py
@@ -47,9 +47,12 @@ def _check_time_dependent_axis(axis: VariableAxis, axis_index, time_axis: Variab
 
 
 def _check_time_independent_axis(axis: VariableAxis, axis_index, values: DataContainer):
-    if axis.shape[0] != values.shape[axis_index]:
+    # an axis spanning every non-time dimension gives a coordinate per data cell instead of one
+    # value per index, the way CDAWeb ships map products (GOLD's latitude/longitude grids). Same
+    # allowance as the time dependent case above, where the grid also varies with time.
+    if (axis.shape != values.shape[1:]) and (axis.shape[0] != values.shape[axis_index]):
         raise ValueError(
-            f"Axis {axis_index} must match data shape, got {axis.shape[0]} and {values.shape[axis_index]}"
+            f"Axis {axis_index} must match data shape, got axis:{axis.shape} and values:{values.shape}"
         )
 
 
@@ -331,14 +334,23 @@ class SpeasyVariable(SpeasyProduct):
         if axis is None or self.ndim == other.ndim:
             return deepcopy(self.__axes)
         else:
-            axes = []
-            for i, ax in enumerate(self.__axes):
-                if i != axis:
-                    # needs to reduce axis
-                    if len(ax.shape) == len(self.values.shape):
-                        ax = np.mean(ax, axis=axis, keepdims=False)
-                    axes.append(deepcopy(ax))
-            return axes
+            return [deepcopy(self.__reduce_axis(i, ax, axis))
+                    for i, ax in enumerate(self.__axes) if i != axis]
+
+    def __reduce_axis(self, index: int, ax, reduced_dimension: int):
+        """Drops the reduced dimension from an axis that carries a coordinate per data cell.
+
+        Such an axis spans the data's dimensions, so losing one of them means losing the same
+        dimension of the axis -- offset by one when the axis does not carry the time dimension.
+        Axes holding one value per index are unaffected, they never described that dimension.
+        """
+        if index == 0:
+            return ax
+        if ax.shape == self.values.shape:
+            return np.mean(ax, axis=reduced_dimension, keepdims=False)
+        if ax.shape == self.values.shape[1:]:
+            return np.mean(ax, axis=reduced_dimension - 1, keepdims=False)
+        return ax
 
     def __array_function__(self, func, types, args, kwargs):
         if func.__name__ in SpeasyVariable.__LIKE_NP_FUNCTIONS__:

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -523,6 +523,15 @@ class DirectArchiveConverter(unittest.TestCase):
         self.assertIsNotNone(fname_regex.search(test_url))
         self.assertIsNotNone(url_pattern.search(test_url))
 
+    @data("aim_cips_sci_3a_2007-144_%Q.20_r05.nc", "gold_l2_nmax_2018_278_v05_r01_c01.nc")
+    def test_dateless_file_naming_under_dated_folders_is_a_sample_not_a_pattern(self, file_naming):
+        # five CDAWeb datasets describe their files with one real file name instead of a pattern.
+        # The year folders give it away: a single fixed file would not be foldered by year. Taken
+        # literally the name resolves that same file for every year asked for, so those datasets
+        # cannot be served from the archive at all.
+        self.assertIsNone(to_direct_archive_params(file_naming=file_naming, subdivided_by="%Y",
+                                                   url="https://cdaweb.gsfc.nasa.gov/pub/data/somewhere"))
+
     @data("omni2.cdf", "voyager1.cdf", "helios1.cdf", "pioneer10.cdf", "ulysses.cdf")
     def test_dateless_file_naming_is_not_a_random_split(self, file_naming):
         # CDAWeb describes nine datasets as a single file whose name carries no date at all. The
@@ -537,15 +546,15 @@ class DirectArchiveConverter(unittest.TestCase):
     def test_best_method_does_not_warn_when_it_falls_back_to_the_web_service(self):
         # BEST means "use whichever works", so falling back is its normal outcome, not something to
         # warn about. mode_is_best compared the method against the lowercase 'best' while the
-        # documented and default value is 'BEST', so every fallback warned. 123 CDAWeb datasets are
-        # NetCDF and always take this path.
+        # documented and default value is 'BEST', so every fallback warned. A dozen CDAWeb datasets
+        # cannot be described as an archive at all and always take this path.
         from unittest.mock import patch
 
-        netcdf_dataset = next(ds for ds in spz.inventories.flat_inventories.cda.datasets.values()
-                              if to_direct_archive_params(file_naming=ds.filenaming,
-                                                          subdivided_by=ds.subdividedby,
-                                                          url=ds.url) is None)
-        variable = next(iter(v for v in netcdf_dataset.__dict__.values() if hasattr(v, 'spz_uid')))
+        undescribable_dataset = next(ds for ds in spz.inventories.flat_inventories.cda.datasets.values()
+                                     if to_direct_archive_params(file_naming=ds.filenaming,
+                                                                 subdivided_by=ds.subdividedby,
+                                                                 url=ds.url) is None)
+        variable = next(iter(v for v in undescribable_dataset.__dict__.values() if hasattr(v, 'spz_uid')))
 
         with patch.object(spz.cda, '_get_data_with_ws', return_value=None) as web_service:
             with self.assertNoLogs('speasy.data_providers.cda', level='WARNING'):

--- a/tests/test_cdaweb_netcdf_direct_archive.py
+++ b/tests/test_cdaweb_netcdf_direct_archive.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""CDAWeb's 70 NetCDF datasets, served by direct file access when the codec can read them.
+
+See https://github.com/SciQLop/speasy/issues/332: the container format says nothing about whether
+the ISTP codec can read a file, so eligibility is settled by probing one real file. No CDAWeb
+NetCDF dataset passes that probe today -- 65 of the 70 expose none but VIRTUAL parameters, four
+are described with a sample file name instead of a pattern, and the last one makes pyistp raise --
+so what these tests mostly pin down is that each of those cases falls back to the REST API.
+"""
+
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ddt import data, ddt
+
+from speasy.core.codecs import get_codec
+from speasy.data_providers.cda import _archive_params_for
+from speasy.data_providers.cda._direct_archive import to_direct_archive_params
+
+try:
+    import netCDF4
+except ImportError:
+    netCDF4 = None
+
+ICON = ('icon_l2-1_mighti-a_los-wind-green_%Y%m%d_v06r000.nc', '%Y',
+        'https://cdaweb.gsfc.nasa.gov/pub/data/icon/l2/l2-1_mighti-a_los-wind-green')
+
+
+@ddt
+class TestFileFormatSelectsCodec(unittest.TestCase):
+
+    def test_netcdf_datasets_are_read_with_the_netcdf_codec(self):
+        file_naming, subdivided_by, url = ICON
+        params = to_direct_archive_params(file_naming=file_naming, subdivided_by=subdivided_by, url=url)
+        self.assertEqual(params['codec'], 'nc')
+
+    def test_cdf_datasets_keep_the_default_reader(self):
+        params = to_direct_archive_params(file_naming='mms1_fgm_srvy_l2_%Y%m%d_%Q.cdf', subdivided_by='%Y/%m',
+                                          url='https://cdaweb.gsfc.nasa.gov/pub/data/mms/mms1/fgm/srvy/l2')
+        self.assertNotIn('codec', params)
+
+    @data('timed_L1Cdisk_guvi_1216A_SP_Movies_%Y%m%d%H%M%S_%Q.gif', 'po_h0_uvi_%Y%m%d_%Q.mpg')
+    def test_formats_speasy_cannot_read_have_no_archive_params(self, file_naming):
+        self.assertIsNone(to_direct_archive_params(file_naming=file_naming, subdivided_by='%Y',
+                                                   url='https://cdaweb.gsfc.nasa.gov/pub/data/somewhere'))
+
+
+def _regular_parameter():
+    return SimpleNamespace()
+
+
+def _cdaweb_dataset(url: str, file_naming: str = 'probe_%Y%m%d_v01.nc', subdivided_by: str = 'None',
+                    master_cdf: str = 'https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/probe.cdf'):
+    return SimpleNamespace(filenaming=file_naming, subdividedby=subdivided_by, url=url, mastercdf=master_cdf)
+
+
+class TestCdfDatasetsAreServedWithoutProbing(unittest.TestCase):
+
+    def test_cdf_datasets_are_given_their_master(self):
+        params = _archive_params_for(_cdaweb_dataset(url='https://cdaweb.gsfc.nasa.gov/pub/data/probe',
+                                                     file_naming='probe_%Y%m%d_%Q.cdf'),
+                                     _regular_parameter(), 'DENSITY', '2020-01-02', '2020-01-03')
+        self.assertEqual(params['master_cdf_url'],
+                         'https://cdaweb.gsfc.nasa.gov/pub/software/cdawlib/0MASTERS/probe.cdf')
+
+    def test_virtual_parameters_are_never_served_from_files(self):
+        self.assertIsNone(_archive_params_for(_cdaweb_dataset(url='https://cdaweb.gsfc.nasa.gov/pub/data/probe',
+                                                              file_naming='probe_%Y%m%d_%Q.cdf'),
+                                              SimpleNamespace(VIRTUAL='TRUE'), 'DENSITY',
+                                              '2020-01-02', '2020-01-03'))
+
+
+class TestUnavailableCodecFallsBackToTheWebService(unittest.TestCase):
+
+    def test_dataset_whose_codec_is_not_installed_is_not_served_from_files(self):
+        # netCDF4 has no WASM/Pyodide wheel, so the NetCDF codec isn't registered there at all and
+        # get_codec('nc') answers None
+        with tempfile.TemporaryDirectory() as archive:
+            open(os.path.join(archive, 'probe_20200102_v01.nc'), 'w').close()
+            with patch('speasy.data_providers.cda.get_codec', return_value=None):
+                self.assertIsNone(_archive_params_for(_cdaweb_dataset(url=archive), _regular_parameter(),
+                                                      'DENSITY', '2020-01-02', '2020-01-03'))
+
+
+def _write_netcdf(path: str, istp: bool):
+    """One tiny NetCDF file, with or without the DEPEND_0/VAR_TYPE attributes pyistp needs."""
+    ds = netCDF4.Dataset(path, 'w')
+    ds.createDimension('time', 3)
+    epoch = ds.createVariable('Epoch', 'f8', ('time',))
+    epoch.units = 'seconds since 1970-01-01'
+    epoch[:] = [0., 60., 120.]
+    density = ds.createVariable('DENSITY', 'f4', ('time',))
+    density[:] = [1., 2., 3.]
+    if istp:
+        epoch.VAR_TYPE = 'support_data'
+        density.VAR_TYPE = 'data'
+        density.DEPEND_0 = 'Epoch'
+    ds.close()
+
+
+@unittest.skipIf(netCDF4 is None, "netCDF4 not installed")
+class TestNetCDFDatasetsAreProbedBeforeServingFiles(unittest.TestCase):
+
+    def _params_for(self, archive_holds: str, start_time: str, stop_time: str, istp: bool = True,
+                    file_naming: str = 'probe_%Y%m%d_v01.nc', variable: str = 'DENSITY'):
+        with tempfile.TemporaryDirectory() as archive:
+            _write_netcdf(os.path.join(archive, archive_holds), istp=istp)
+            return _archive_params_for(_cdaweb_dataset(url=archive, file_naming=file_naming),
+                                       _regular_parameter(), variable, start_time, stop_time)
+
+    def test_istp_conformant_dataset_is_served_from_files(self):
+        params = self._params_for('probe_20200102_v01.nc', '2020-01-02', '2020-01-03')
+        self.assertEqual(params['codec'], 'nc')
+
+    def test_netcdf_datasets_are_not_given_a_master_cdf(self):
+        # IstpNetCDF.load_variable forwards unknown kwargs down to _load_variables(variables, file,
+        # buffer), which would raise TypeError on master_cdf_url
+        params = self._params_for('probe_20200102_v01.nc', '2020-01-02', '2020-01-03')
+        self.assertNotIn('master_cdf_url', params)
+
+    def test_dataset_the_codec_reads_nothing_from_falls_back_to_the_web_service(self):
+        # plain NetCDF, no ISTP attributes: direct access would yield an empty dataset, which is
+        # strictly worse than the REST API answer it replaces
+        self.assertIsNone(self._params_for('probe_20200102_v01.nc', '2020-01-02', '2020-01-03', istp=False))
+
+    def test_dataset_with_no_file_in_the_requested_range_falls_back_to_the_web_service(self):
+        # nothing to probe means nothing proven
+        self.assertIsNone(self._params_for('probe_20200102_v01.nc', '2019-06-01', '2019-06-02'))
+
+    def test_variable_missing_from_the_files_falls_back_to_the_web_service(self):
+        # the file lists variables, just not the one asked for
+        self.assertIsNone(self._params_for('probe_20200102_v01.nc', '2020-01-02', '2020-01-03',
+                                           variable='SOMETHING_ELSE'))
+
+    def test_variable_the_codec_chokes_on_falls_back_to_the_web_service(self):
+        # listing a variable doesn't mean the codec can load it: on the real
+        # ICON_L2-7_IVM-A files pyistp lists 125 variables and then raises
+        # "AttributeError: NetCDF: Attribute not found" while walking ICON_L27_GPS_Epoch's axes
+        with patch.object(get_codec('nc'), 'load_variable', side_effect=AttributeError("NetCDF: Attribute not found")):
+            self.assertIsNone(self._params_for('probe_20200102_v01.nc', '2020-01-02', '2020-01-03'))
+
+    def test_single_file_dataset_is_probed_through_the_folder_listing(self):
+        # a dataset held in one fixed file is a regular split, which resolves its file differently
+        params = self._params_for('the_whole_mission.nc', '2018-10-05', '2018-10-06',
+                                  file_naming='the_whole_mission.nc')
+        self.assertEqual(params['codec'], 'nc')
+
+    def test_single_file_dataset_whose_file_is_missing_falls_back_to_the_web_service(self):
+        self.assertIsNone(self._params_for('something_else.nc', '2018-10-05', '2018-10-06',
+                                           file_naming='the_whole_mission.nc'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_codec_coordinate_grids.py
+++ b/tests/test_codec_coordinate_grids.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Codecs round-tripping variables whose axes give a coordinate per data cell.
+
+Two shapes reach the writers: CDAWeb map products such as GOLD_L2_ON2, whose latitude and
+longitude grids span the non-time dimensions, and PSP_ISOIS-EPILO_L2-PE, whose energy grid spans
+every dimension including time. Both used to be written against a single dimension sized from one
+of their own, which either raised or lost the record-varying flag on the way back.
+"""
+
+import unittest
+
+import numpy as np
+from ddt import data, ddt, unpack
+
+from speasy.core.codecs import get_codec
+from speasy.core.data_containers import DataContainer, VariableAxis, VariableTimeAxis
+from speasy.products import SpeasyVariable
+
+try:
+    import netCDF4
+except ImportError:
+    netCDF4 = None
+
+_TIME = np.arange('2018-10-05', '2018-10-05T00:01', np.timedelta64(10, 's'), dtype='datetime64[ns]')
+_N, _H, _D = len(_TIME), 5, 3
+
+
+def coordinate_grids() -> SpeasyVariable:
+    """GOLD_L2_ON2's shape: latitude and longitude grids over the two spatial dimensions."""
+    return SpeasyVariable(
+        axes=[VariableTimeAxis(values=_TIME),
+              VariableAxis(name='latitude', values=np.random.random((_H, _D))),
+              VariableAxis(name='longitude', values=np.random.random((_H, _D)))],
+        values=DataContainer(np.random.random((_N, _H, _D)), is_time_dependent=True, name='on2',
+                             meta={"VAR_TYPE": "data", "DISPLAY_TYPE": "map_image"}),
+        columns=["Values"])
+
+
+def record_varying_grid() -> SpeasyVariable:
+    """PSP_ISOIS-EPILO_L2-PE's shape: an energy grid given for every (time, look direction) cell."""
+    return SpeasyVariable(
+        axes=[VariableTimeAxis(values=_TIME),
+              VariableAxis(name='look_direction', values=np.arange(_H).astype(np.float64)),
+              VariableAxis(name='energy', values=np.random.random((_N, _H, _D)), is_time_dependent=True)],
+        values=DataContainer(np.random.random((_N, _H, _D)), is_time_dependent=True, name='counts',
+                             meta={"VAR_TYPE": "data", "DISPLAY_TYPE": "spectrogram"}),
+        columns=["Values"])
+
+
+def plain_spectrogram() -> SpeasyVariable:
+    """One value per index, the shape that already worked, kept so the fix stays a superset."""
+    return SpeasyVariable(
+        axes=[VariableTimeAxis(values=_TIME),
+              VariableAxis(name='energy', values=np.arange(_H).astype(np.float64))],
+        values=DataContainer(np.random.random((_N, _H)), is_time_dependent=True, name='flux',
+                             meta={"VAR_TYPE": "data", "DISPLAY_TYPE": "spectrogram"}),
+        columns=["Values"])
+
+
+def _round_trip(codec_name: str, var: SpeasyVariable) -> SpeasyVariable:
+    buffer = get_codec(codec_name).save_variables([var])
+    return get_codec(codec_name).load_variable(var.name, file=bytes(buffer), disable_cache=True)
+
+
+@ddt
+class CoordinateGridsSurviveACdfRoundTrip(unittest.TestCase):
+
+    @data(coordinate_grids, record_varying_grid, plain_spectrogram)
+    def test_shapes_are_preserved(self, ctor):
+        var = ctor()
+        back = _round_trip('cdf', var)
+        self.assertIsNotNone(back)
+        self.assertEqual(back.values.shape, var.values.shape)
+        self.assertListEqual([ax.shape for ax in back.axes], [ax.shape for ax in var.axes])
+
+    @data(coordinate_grids, record_varying_grid, plain_spectrogram)
+    def test_time_dependence_is_preserved(self, ctor):
+        # a record-varying axis written without DEPEND_0 comes back time independent, and then
+        # matches no dimension of the data at all
+        var = ctor()
+        back = _round_trip('cdf', var)
+        self.assertListEqual([ax.is_time_dependent for ax in back.axes],
+                             [ax.is_time_dependent for ax in var.axes])
+
+    @data(coordinate_grids, record_varying_grid, plain_spectrogram)
+    def test_values_are_preserved(self, ctor):
+        var = ctor()
+        back = _round_trip('cdf', var)
+        np.testing.assert_array_almost_equal(back.values, var.values)
+
+
+@unittest.skipIf(netCDF4 is None, "netCDF4 not installed")
+@ddt
+class CoordinateGridsSurviveANetCdfRoundTrip(unittest.TestCase):
+
+    @data(coordinate_grids, record_varying_grid, plain_spectrogram)
+    def test_shapes_are_preserved(self, ctor):
+        var = ctor()
+        back = _round_trip('nc', var)
+        self.assertIsNotNone(back)
+        self.assertEqual(back.values.shape, var.values.shape)
+        self.assertListEqual([ax.shape for ax in back.axes], [ax.shape for ax in var.axes])
+
+    @data(coordinate_grids, record_varying_grid, plain_spectrogram)
+    def test_values_are_preserved(self, ctor):
+        var = ctor()
+        back = _round_trip('nc', var)
+        np.testing.assert_array_almost_equal(back.values, var.values)
+
+    @data((coordinate_grids, ('dim_latitude', 'dim_longitude'), (_H, _D)),
+          (record_varying_grid, ('dim_look_direction', 'dim_energy'), (_H, _D)))
+    @unpack
+    def test_each_data_dimension_gets_its_own_size(self, ctor, dimension_names, sizes):
+        # both grids used to size their dimension from their own first (or last) axis, so the two
+        # spatial dimensions ended up sharing one size and nothing fitted
+        buffer = get_codec('nc').save_variables([ctor()])
+        with netCDF4.Dataset('probe', mode='r', memory=bytes(buffer)) as ds:
+            self.assertEqual(tuple(len(ds.dimensions[name]) for name in dimension_names), sizes)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_plotting_hints.py
+++ b/tests/test_plotting_hints.py
@@ -133,5 +133,128 @@ class ColormapHints(unittest.TestCase):
         self.assertTrue(np.ma.getmaskarray(mesh.get_array()).all())
 
 
+_MAP_TIME = np.array(["2018-10-05", "2018-10-06"], dtype="datetime64[ns]")
+
+
+def _map_plot(display_type="map_image>THUMBSIZE>166>MAP_PROJ>7>SMOOTH>x=latitude,y=longitude",
+              time_dependent_grids=False):
+    """A GOLD_L2_ON2 shaped variable: latitude and longitude grids over the two spatial dims."""
+    latitude = np.array([[0., 0., 0.], [1., 1., 1.]])
+    longitude = np.array([[0., 1., 2.], [0., 1., 2.]])
+    if time_dependent_grids:
+        latitude = np.stack([latitude, latitude])
+        longitude = np.stack([longitude, longitude])
+    return Plot(
+        axes=[VariableTimeAxis(values=_MAP_TIME),
+              VariableAxis(values=latitude, name="latitude", is_time_dependent=time_dependent_grids),
+              VariableAxis(values=longitude, name="longitude", is_time_dependent=time_dependent_grids)],
+        values=DataContainer(values=np.arange(12.).reshape(2, 2, 3),
+                             meta={"DISPLAY_TYPE": display_type}, name="on2"),
+        columns_names=["value"],
+    )
+
+
+class DisplayTypeDispatch(unittest.TestCase):
+    """DISPLAY_TYPE was compared whole, so anything carrying modifiers fell through to a line plot.
+
+    1012 CDAWeb parameters spell it 'spectrogram>y=...,z=...' rather than plain 'spectrogram'.
+    """
+
+    def setUp(self):
+        self.addCleanup(plt.close, "all")
+
+    def test_plain_spectrogram_is_a_colormap(self):
+        ax = _colormap_plot(values_meta={"DISPLAY_TYPE": "spectrogram"})()
+        self.assertEqual(len(ax.collections), 1)
+
+    def test_spectrogram_with_modifiers_is_a_colormap(self):
+        ax = _colormap_plot(
+            values_meta={"DISPLAY_TYPE": "spectrogram>y=Center_Scan, z=MEDUSA_Electron(1,*)"})()
+        self.assertEqual(len(ax.collections), 1)
+
+    def test_time_series_is_a_line(self):
+        ax = _line_plot(values_meta={"DISPLAY_TYPE": "time_series"})()
+        self.assertEqual(len(ax.get_lines()), 1)
+
+    def test_no_display_type_is_a_line(self):
+        ax = _line_plot()()
+        self.assertEqual(len(ax.get_lines()), 1)
+
+    def test_map_image_is_a_colormap(self):
+        ax = _map_plot()()
+        self.assertEqual(len(ax.collections), 1)
+
+
+class ColormapOverCoordinateGrids(unittest.TestCase):
+    """A map is a colormap whose axes happen to be grids, not a plot type of its own."""
+    def setUp(self):
+        self.addCleanup(plt.close, "all")
+
+    def test_uses_the_coordinate_grids_named_by_the_hint(self):
+        # CDAWeb spells GOLD's hint 'x=latitude,y=longitude', so the axes are not in array order
+        ax = _map_plot().colormap()
+        self.assertEqual(ax.get_xlabel(), "latitude")
+        self.assertEqual(ax.get_ylabel(), "longitude")
+
+    def test_falls_back_to_array_order_without_a_hint(self):
+        ax = _map_plot(display_type="map_image").colormap()
+        self.assertEqual(ax.get_xlabel(), "longitude")
+        self.assertEqual(ax.get_ylabel(), "latitude")
+
+    def test_plots_one_time_step(self):
+        ax = _map_plot().colormap(time_index=1)
+        mesh = ax.collections[0]
+        self.assertEqual(mesh.get_array().size, 6)
+
+    def test_grids_with_holes_still_draw(self):
+        # 37% of GOLD_L2_ON2's grid is NaN, the cells looking off the Earth's disk, and
+        # pcolormesh refuses non-finite coordinates outright
+        plot = _map_plot()
+        plot.axes[1].values[0, 0] = np.nan
+        plot.axes[2].values[0, 0] = np.nan
+        ax = plot.colormap()
+        self.assertEqual(len(ax.collections), 1)
+
+    def test_record_varying_grids_are_indexed_by_time_too(self):
+        ax = _map_plot(time_dependent_grids=True).colormap(time_index=1)
+        self.assertEqual(len(ax.collections), 1)
+
+
+class ColormapRefusesMoreThanTwoDimensions(unittest.TestCase):
+    def setUp(self):
+        self.addCleanup(plt.close, "all")
+
+    def test_one_grid_among_plain_axes_is_not_a_map(self):
+        # PSP_ISOIS-EPILO_L2-PE has a plain look direction axis and an energy grid over every
+        # dimension. Only one of its two spatial dimensions has a coordinate, so there is nothing
+        # to spread a map over and it must ask for a reduction like any other 3D spectrogram.
+        plot = Plot(
+            axes=[VariableTimeAxis(values=_MAP_TIME),
+                  VariableAxis(values=np.arange(2.), name="look_direction"),
+                  VariableAxis(values=np.random.random((2, 2, 3)), name="energy",
+                               is_time_dependent=True)],
+            values=DataContainer(values=np.arange(12.).reshape(2, 2, 3),
+                                 meta={"DISPLAY_TYPE": "spectrogram"}, name="counts"),
+            columns_names=["value"])
+        with self.assertRaises(ValueError) as e:
+            plot.colormap()
+        self.assertIn("3 dimensions", str(e.exception))
+
+    def test_error_names_the_way_out(self):
+        # PSP_ISOIS-EPILO_L2-PE is a 3D spectrogram; matplotlib used to answer with an opaque
+        # "Dimensions of C (3, 5, 6) should be one smaller than X(6) and Y(5)"
+        plot = Plot(
+            axes=[VariableTimeAxis(values=_MAP_TIME),
+                  VariableAxis(values=np.arange(2.), name="look_direction"),
+                  VariableAxis(values=np.arange(3.), name="energy")],
+            values=DataContainer(values=np.arange(12.).reshape(2, 2, 3),
+                                 meta={"DISPLAY_TYPE": "spectrogram"}, name="counts"),
+            columns_names=["value"])
+        with self.assertRaises(ValueError) as e:
+            plot.colormap()
+        self.assertIn("3 dimensions", str(e.exception))
+        self.assertIn("axis=", str(e.exception))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_speasy_variable.py
+++ b/tests/test_speasy_variable.py
@@ -81,6 +81,87 @@ def make_2d_var_1d_y(start: float = 0., stop: float = 0., step: float = 1., coef
         values=DataContainer(values, is_time_dependent=True), columns=["Values"])
 
 
+def make_var_with_per_cell_coordinates(start: float = 0., stop: float = 10., step: float = 1.,
+                                       height: int = 5, depth: int = 3):
+    """A variable whose extra axes are coordinate grids spanning every non-time dimension.
+
+    That is how CDAWeb ships map products such as GOLD_L2_ON2: DEPEND_1 and DEPEND_2 both point
+    at the full latitude/longitude grid rather than at one vector per dimension, and both are
+    non-record-varying. Same construct as PSP_ISOIS-EPILO's energy axis (see make_var_with_
+    record_varying_per_cell_coordinate), only time independent.
+    """
+    time = np.arange(start, stop, step)
+    values = np.random.random((len(time), height, depth))
+    latitude = np.repeat(np.arange(height), depth).reshape(height, depth).astype(np.float64)
+    longitude = np.tile(np.arange(depth), height).reshape(height, depth).astype(np.float64)
+    return SpeasyVariable(
+        axes=[VariableTimeAxis(values=epoch_to_datetime64(time)),
+              VariableAxis(name='latitude', values=latitude),
+              VariableAxis(name='longitude', values=longitude)],
+        values=DataContainer(values, is_time_dependent=True, meta={"DISPLAY_TYPE": "map_image"}),
+        columns=["Values"])
+
+
+def make_var_with_record_varying_per_cell_coordinate(start: float = 0., stop: float = 10., step: float = 1.,
+                                                     height: int = 5, depth: int = 3):
+    """PSP_ISOIS-EPILO_L2-PE's shape: an energy axis given for every (time, look direction) cell.
+
+    Kept as a regression guard for https://github.com/SciQLop/speasy/issues/225.
+    """
+    time = np.arange(start, stop, step)
+    values = np.random.random((len(time), height, depth))
+    return SpeasyVariable(
+        axes=[VariableTimeAxis(values=epoch_to_datetime64(time)),
+              VariableAxis(name='look_direction', values=np.arange(height)),
+              VariableAxis(name='energy', values=np.random.random((len(time), height, depth)),
+                           is_time_dependent=True)],
+        values=DataContainer(values, is_time_dependent=True, meta={"DISPLAY_TYPE": "spectrogram"}),
+        columns=["Values"])
+
+
+@ddt
+class PerCellCoordinateAxes(unittest.TestCase):
+    """Axes that give a coordinate per data cell instead of one value per index.
+
+    Issue #225 taught _check_time_dependent_axis about them; the time independent branch never
+    learned, which is why GOLD_L2_ON2 could not be loaded at all.
+    """
+
+    def test_time_independent_coordinate_grids_are_accepted(self):
+        var = make_var_with_per_cell_coordinates()
+        self.assertEqual(var.values.shape, (10, 5, 3))
+        self.assertEqual(var.axes[1].shape, (5, 3))
+        self.assertEqual(var.axes[2].shape, (5, 3))
+
+    def test_record_varying_coordinate_grid_is_still_accepted(self):
+        var = make_var_with_record_varying_per_cell_coordinate()
+        self.assertEqual(var.axes[2].shape, (10, 5, 3))
+
+    def test_an_axis_that_matches_no_dimension_is_still_refused(self):
+        with self.assertRaises(ValueError) as e:
+            SpeasyVariable(
+                axes=[VariableTimeAxis(values=epoch_to_datetime64(np.arange(3.))),
+                      VariableAxis(name='nonsense', values=np.arange(8).reshape(4, 2).astype(np.float64))],
+                values=DataContainer(values=np.random.random((3, 5, 3)), is_time_dependent=True),
+                columns=["Values"])
+        self.assertIn("must match data shape", str(e.exception))
+
+    @data(np.sum, np.mean, np.max, np.min)
+    def test_reducing_a_dimension_reduces_the_coordinate_grids(self, func):
+        var = make_var_with_per_cell_coordinates()
+        for axis, remaining in ((1, (3,)), (2, (5,))):
+            result = func(var, axis=axis)
+            self.assertEqual(len(result.axes), 2)
+            self.assertEqual(result.axes[1].shape, remaining)
+
+    @data(np.sum, np.mean, np.max, np.min)
+    def test_reducing_a_dimension_reduces_a_record_varying_grid(self, func):
+        var = make_var_with_record_varying_per_cell_coordinate()
+        result = func(var, axis=1)
+        self.assertEqual(len(result.axes), 2)
+        self.assertEqual(result.axes[1].shape, (10, 3))
+
+
 @ddt
 class SpeasyVariableSlice(unittest.TestCase):
 


### PR DESCRIPTION
Closes #332.

`to_direct_archive_params()` rejected anything not named `*.cdf`, so the 70 NetCDF datasets always
went through the REST API even though Speasy ships a NetCDF codec. The file name now maps to a
codec, and eligibility is settled by a lazy, disk-cached probe rather than by the container format.

### What the probe does

It loads the **requested variable** from the first file the archive would serve, and remembers the
answer for a week (`@CacheCall(cache_retention=timedelta(days=7), is_pure=True)`).

Issue #332 proposed keying on `list_variables()` being non-empty. That turned out to be necessary
but not sufficient: on the real `ICON_L2-7_IVM-A` files pyistp lists 125 variables and *then*
raises `AttributeError: NetCDF: Attribute not found` while walking the axes of the one parameter
that is not `VIRTUAL`. With a list-only probe, `method='FILE'` would have crashed where the REST
API works today.

It keys on a file and a variable, never on `get_data()` returning `None` — `None` is the normal
answer for a time range the dataset does not cover, and caching that as "unreadable" would poison
a working dataset because someone asked for a quiet week.

### Two other things that had to be handled

- A file name with **no date under folders that have one** is CDAWeb quoting one real file rather
  than a pattern — four GOLD datasets and `AIM_CIPS_SCI_3A`, e.g.
  `gold_l2_nmax_2018_278_v05_r01_c01.nc` under `%Y`. Taken literally it resolves that same file for
  every year asked for, so those datasets are refused outright. No CDF dataset has that shape, so
  nothing changes for them.
- NetCDF files have no master, and forwarding `master_cdf_url` to the NetCDF codec would raise
  `TypeError` in `_load_variables(variables, file, buffer)`, so it is only passed on the CDF path.

`get_codec('nc')` is also checked for `None`: the codec is registered conditionally and is absent
where netCDF4 has no wheel (WASM/Pyodide).

### Honest scope: no dataset changes behaviour today

Measured against the live inventory, of the 70 NetCDF datasets:

| | |
|---|---|
| 65 | expose only `VIRTUAL='TRUE'` parameters, which CDAWeb computes server-side and `_is_virtual_parameter` already excluded |
| 4 + 1 | the GOLD/AIM sample-name descriptors above |
| 1 | `ICON_L2-7_IVM-A`, whose only real parameter makes pyistp raise |

For contrast, 2559 of the 2850 CDF datasets have at least one non-virtual parameter — the NetCDF
ones are the anomaly, not the rule. So this does not unlock the 70 datasets #332 hoped for; it
makes the decision a property of what the codec can actually read, fixes the sample-name trap, and
opens the door for ISTP NetCDF datasets to come.

### Verification

- New `tests/test_cdaweb_netcdf_direct_archive.py`, written test-first: format→codec mapping, the
  CDF path keeping its master, virtual parameters, missing codec, non-ISTP files, a missing
  variable, a codec that raises, and both split rules resolving (or failing to resolve) a file.
- `tests/test_cdaweb.py::DirectArchiveConverter` (38) and
  `test_direct_archive_downloader` / `test_netcdf_codec` / `test_codecs` (65) pass locally.
- Live FILE-vs-API runs on ICON and GOLD confirm both fall back to the REST API instead of
  crashing or returning empty data.

### Out of scope, found on the way

- pyistp's NetCDF driver raises `AttributeError: NetCDF: Attribute not found` in `_get_axis` on
  `ICON_L2-7_IVM-A` files — reproducible with `get_codec('nc').load_variable(...)` alone.
- `GOLD_L2_ON2/on2` fails on the **API** path with
  `ValueError: Axis 2 must match data shape, got 52 and 46`. Untouched by this branch.
- pyistp's NetCDF driver spawns a worker process, so a plain script touching the `nc` codec at
  module level without `if __name__ == '__main__':` dies during bootstrap. Already true for
  `generic_archive` `codec: nc`, but this widens the exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
