### PR TITLE
Fix seven bugs found auditing the 1.8.0 release surface

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-concurrency = multiprocessing
+concurrency = multiprocessing, thread
 parallel = true
 sigterm = true
 

--- a/speasy/core/cache/_function_cache.py
+++ b/speasy/core/cache/_function_cache.py
@@ -86,8 +86,11 @@ class CacheCall(object):
                     if result is not None:
                         return result
                     return self.add_to_cache(cache_entry, function(*args, **kwargs))
-            return self.get_from_cache(cache_entry, prefer_cache=prefer_cache) or self.add_to_cache(
-                cache_entry, function(*args, **kwargs))
+            # Whoever we waited for may have cached a falsy value, which is still a cached value.
+            result = self.get_from_cache(cache_entry, prefer_cache=prefer_cache)
+            if result is not None:
+                return result
+            return self.add_to_cache(cache_entry, function(*args, **kwargs))
 
         setattr(wrapped, "drop_entries", self.drop_entries)
         if self._leak_cache:

--- a/speasy/core/cdf/inventory_extractor.py
+++ b/speasy/core/cdf/inventory_extractor.py
@@ -73,7 +73,7 @@ def extract_parameter(cdf: ISTPLoader, var_name: str, provider: str, uid_fmt: st
             return ParameterIndex(name=var_name, provider=provider, uid=uid_fmt.format(var_name=var_name),
                                   meta={**filter_variable_meta(datavar), **meta})
     except (IndexError, RuntimeError) as e:
-        print(f"Issue loading {var_name} from {cdf}")
+        log.warning(f"Issue loading {var_name} from {cdf}: {e}")
 
     return None
 
@@ -99,8 +99,8 @@ def extract_parameters(url_or_istp_loader: Union[str,ISTPLoader], provider: str,
         else:
             return _extract_parameters_impl(url_or_istp_loader, provider=provider, uid_fmt=uid_fmt, meta=meta, enable_cda_trick=enable_cda_trick)
 
-    except RuntimeError:
-        print(f"Issue loading {url_or_istp_loader}")
+    except RuntimeError as e:
+        log.warning(f"Issue loading {url_or_istp_loader}: {e}")
     return indexes
 
 
@@ -115,8 +115,8 @@ def extract_from_master(url: str, provider: str, params_uid_format: str = "{var_
             parameters = _extract_parameters_impl(istp, provider=provider, uid_fmt=params_uid_format, meta=params_meta)
             dataset_meta = filter_dataset_meta(istp)
             return parameters, dataset_meta
-    except RuntimeError:
-        print(f"Issue loading {url}")
+    except RuntimeError as e:
+        log.warning(f"Issue loading {url}: {e}")
     return None
 
 

--- a/speasy/core/codecs/bundled_codecs/hapi/binary/reader.py
+++ b/speasy/core/codecs/bundled_codecs/hapi/binary/reader.py
@@ -49,7 +49,9 @@ def load_hapi_binary(file: Union[Buffer, str, io.IOBase]) -> Optional[HapiFile]:
     if data is not None and headers is not None:
         time_header = headers["parameters"][0]
         assert time_header["type"] == "isotime"
-        data_time = np.char.rstrip(data["Time"].astype("U24"), "Z").astype("datetime64[ns]")
+        # Widen to whatever length the server declared, truncating loses precision silently.
+        data_time = np.char.rstrip(data["Time"].astype(f"U{data['Time'].dtype.itemsize}"), "Z").astype(
+            "datetime64[ns]")
         hapi_binary_file.create_parameter(data_time,
                                        meta=time_header)
         for i, param_meta in enumerate(headers["parameters"][1:]):

--- a/speasy/core/codecs/bundled_codecs/hapi/codec.py
+++ b/speasy/core/codecs/bundled_codecs/hapi/codec.py
@@ -20,9 +20,28 @@ def _time_dependent_axis_name(ax: VariableAxis) -> str:
 def _get_variable_axes(variable: SpeasyVariable, is_time_dependent: bool) -> List[VariableAxis]:
     return [ax for ax in variable.axes[1:] if ax.is_time_dependent == is_time_dependent]
 
+# HAPI always spells fill as a string, whatever the parameter's type, while masking compares it
+# against the data, so it has to be read back in the data's own type.
+_fill_value_parsers = {"double": float, "integer": int}
+
+
+def _decode_fill_value(fill: Any, hapi_type: str) -> Any:
+    parser = _fill_value_parsers.get(hapi_type)
+    if parser is None or not isinstance(fill, str):
+        return fill
+    try:
+        return parser(fill)
+    except ValueError:
+        log.warning(f"Ignoring fill value {fill!r}, which is not a valid {hapi_type}")
+        return None
+
+
 def _decode_meta(meta: Dict[str, Any]) -> Dict[str, Any]:
     if "units" in meta:
         meta["UNITS"] = meta.pop("units")
+    fill = _decode_fill_value(meta.pop("fill", None), meta.get("type", ""))
+    if fill is not None:
+        meta["FILLVAL"] = fill
     return meta
 
 def _make_hapi_time_axis(time_axis: VariableTimeAxis) -> HapiParameter:
@@ -35,7 +54,7 @@ def _make_hapi_parameter(variable: SpeasyVariable) -> HapiParameter:
 
 def _numpy_dtype_to_hapi_type(dtype: np.dtype) -> str:
     if  np.issubdtype(dtype, np.integer):
-        return "int"
+        return "integer"
     elif np.issubdtype(dtype, np.floating):
         return "double"
     else:
@@ -46,7 +65,7 @@ def _create_meta(variable:SpeasyVariable) -> Dict[str, Any]:
     meta = {
         "name": variable.name,
         "units": variable.unit,
-        "fill": variable.fill_value,
+        "fill": None if variable.fill_value is None else str(variable.fill_value),
         "description": variable.meta.get("description", "")
     }
     meta["type"] = _numpy_dtype_to_hapi_type(variable.values.dtype)

--- a/speasy/core/direct_archive_downloader/direct_archive_downloader.py
+++ b/speasy/core/direct_archive_downloader/direct_archive_downloader.py
@@ -231,7 +231,12 @@ class RandomSplitDirectDownload:
         for start in spilt_range(split_frequency, start_time, stop_time):
 
             base_ulr = apply_date_format(url_pattern, start)
-            folder_url = base_ulr.rsplit('/', 1)[0]
+            folder_url, folder_regex = base_ulr.rsplit('/', 1)
+
+            if force_refresh:
+                # map_ranges cannot pass it on: CacheCall owns the force_refresh keyword and keeps
+                # it for itself, so the listing map_ranges reads is refreshed from here instead.
+                list_files(folder_url, re.compile(folder_regex), force_refresh=True)
 
             files = filter_ranges(
                 map_ranges(base_ulr, fname_regex=fname_regex, date_format=date_format, force_refresh=force_refresh),
@@ -246,7 +251,8 @@ class RandomSplitDirectDownload:
                     fname_regex: str, split_frequency: str = "daily", date_format=None,
                     file_reader: FileLoaderCallable = _read_cdf, **kwargs) -> Optional[SpeasyVariable]:
 
-        force_refresh = kwargs.pop('force_refresh', False)
+        # kept in kwargs on purpose: it must also reach the file reader's own cache
+        force_refresh = kwargs.get('force_refresh', False)
         downloader = lambda force_refresh: merge(
             randomized_map(
                 partial(file_reader, variable=variable, **kwargs),

--- a/speasy/core/direct_archive_downloader/direct_archive_downloader.py
+++ b/speasy/core/direct_archive_downloader/direct_archive_downloader.py
@@ -33,7 +33,7 @@ def apply_date_format(txt: str, date: datetime) -> str:
         p = 'PM'
     else:
         p = 'AM'
-    return txt.format(Y=date.year, y=str(date.year)[-2:], M=date.month, D=date.day, H=date.hour,
+    return txt.format(Y=date.year, y=date.year % 100, M=date.month, D=date.day, H=date.hour,
                       j=date.timetuple().tm_yday, I=date.hour % 12,
                       p=p)
 

--- a/speasy/core/direct_archive_downloader/direct_archive_downloader.py
+++ b/speasy/core/direct_archive_downloader/direct_archive_downloader.py
@@ -14,7 +14,7 @@ from dateutil.relativedelta import relativedelta
 
 from speasy.core import make_utc_datetime, AnyDateTimeType
 from speasy.core.cache import CacheCall
-from speasy.core.any_files import list_files
+from speasy.core.any_files import list_files as list_remote_files
 from speasy.core.codecs import get_codec
 from speasy.core.span_utils import intersects
 from speasy.products import SpeasyVariable
@@ -67,7 +67,7 @@ def _build_url(url_pattern: str, date: datetime, use_file_list=False, force_refr
     if not use_file_list:
         return base_ulr
     folder_url, rx = base_ulr.rsplit('/', 1)
-    files = list_files(folder_url, re.compile(rx), force_refresh=force_refresh)
+    files = list_remote_files(folder_url, re.compile(rx), force_refresh=force_refresh)
     if len(files):
         return '/'.join((folder_url, max(files, key=_natural_order)))
     return None
@@ -162,7 +162,7 @@ def map_ranges(url, fname_regex: Union[str, re.Pattern], date_format: Optional[s
         fname_regex = re.compile(fname_regex)
     files: List[re.Match] = _drop_superseded_versions(list(
         filter(lambda m: m is not None, map(fname_regex.match,
-                                            list_files(url.rsplit('/', 1)[0],
+                                            list_remote_files(url.rsplit('/', 1)[0],
                                                        re.compile(url.rsplit('/', 1)[1]))))))
     ranges = []
     if len(files):
@@ -236,7 +236,7 @@ class RandomSplitDirectDownload:
             if force_refresh:
                 # map_ranges cannot pass it on: CacheCall owns the force_refresh keyword and keeps
                 # it for itself, so the listing map_ranges reads is refreshed from here instead.
-                list_files(folder_url, re.compile(folder_regex), force_refresh=True)
+                list_remote_files(folder_url, re.compile(folder_regex), force_refresh=True)
 
             files = filter_ranges(
                 map_ranges(base_ulr, fname_regex=fname_regex, date_format=date_format, force_refresh=force_refresh),

--- a/speasy/plotting/mpl_backend/__init__.py
+++ b/speasy/plotting/mpl_backend/__init__.py
@@ -42,13 +42,18 @@ class Plot:
         return ax.pcolor(np.ma.masked_invalid(x), np.ma.masked_invalid(y), z, *args, **kwargs)
 
     def _norm(self, z, logz, vmin, vmax):
-        # A slice that's entirely masked/FILLVAL has no finite value to scale from; fall back to
-        # an arbitrary positive bound rather than feeding LogNorm/Normalize a NaN vmin/vmax.
-        nonzero = z[np.nonzero(z)]
+        # A log scale cannot place zero or negative values, so it scales from the smallest
+        # positive one, while a linear scale uses them all. A slice left with nothing to scale
+        # from -- entirely masked/FILLVAL, or all zeros on a log scale -- falls back to bounds
+        # matplotlib accepts rather than NaN or inverted ones.
+        finite = z[np.isfinite(z)]
+        scalable = finite[finite > 0] if logz else finite
+        if not len(scalable):
+            scalable = np.array([1., 10.])
         if vmin is None:
-            vmin = np.nanmin(nonzero) if np.isfinite(nonzero).any() else 1.0
+            vmin = scalable.min()
         if vmax is None:
-            vmax = np.nanmax(z) if np.isfinite(z).any() else 1.0
+            vmax = scalable.max()
         if logz:
             return colors.LogNorm(vmin=vmin, vmax=vmax)
         return colors.Normalize(vmin=vmin, vmax=vmax)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -655,6 +655,57 @@ class CacheCallRequestsDeduplication(unittest.TestCase):
 
         self.assertLessEqual(run_count["n"], 1)
 
+    def test_loser_reuses_a_cached_falsy_value_instead_of_recomputing_it(self):
+        """A cached value that happens to be falsy -- False, 0, an empty string
+        or an empty variable -- is still a cached value. The fallback a losing
+        thread takes once the owner released picked it up with ``or``, so it
+        recomputed exactly the answers deduplication is worth the most on: the
+        expensive ones that come back empty, like a server reported down.
+
+        Drives the wait-loop path (the loser never owns the lock) rather than
+        the TOCTOU path above, and hooks the loop's own sleep so the owner only
+        releases once the loser is provably waiting.
+        """
+        from unittest import mock
+        from threading import Thread, Event
+        import speasy.core.cache._request_locker as rl
+
+        owner_holds_lock = Event()
+        owner_may_release = Event()
+        loser_is_waiting = Event()
+        run_count = {"n": 0}
+
+        @CacheCall(cache_retention=timedelta(minutes=10), is_pure=True, cache_instance=_cache_call_dedup_fn.cache,
+                   deduplication_timeout=5)
+        def falsy_fn(key):
+            run_count["n"] += 1
+            owner_holds_lock.set()
+            owner_may_release.wait(timeout=2)
+            return ""
+
+        key = f"falsy_cached_value_{id(self)}"
+        real_sleep = rl.sleep
+
+        def signalling_sleep(duration):
+            loser_is_waiting.set()  # only the wait loop of a thread that lost the lock sleeps
+            real_sleep(duration)
+
+        def loser():
+            owner_holds_lock.wait(timeout=2)  # ensure real contention first
+            falsy_fn(key)
+
+        with mock.patch.object(rl, "sleep", side_effect=signalling_sleep):
+            t_owner = Thread(target=falsy_fn, args=(key,))
+            t_loser = Thread(target=loser)
+            t_owner.start()
+            t_loser.start()
+            loser_is_waiting.wait(timeout=2)
+            owner_may_release.set()
+            t_owner.join(timeout=5)
+            t_loser.join(timeout=5)
+
+        self.assertEqual(run_count["n"], 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_cdaweb.py
+++ b/tests/test_cdaweb.py
@@ -404,6 +404,22 @@ class DirectArchiveConverter(unittest.TestCase):
             datetime(1969, 12, 23, tzinfo=timezone.utc)
         ),
         (
+            # DE_VS_EICS names its files with a two-digit year, inside four-digit year folders.
+            "%y%j_eics_de_96s_%Q.cdf",
+            "%Y",
+            "https://cdaweb.gsfc.nasa.gov/pub/data/de/de1/particles_eics/vs_eics_cdaweb",
+            {
+                'date_format': '%y%j',
+                'fname_regex': '(?P<start>\\d+t?T?\\d+)_eics_de_96s_(?P<version>.*).cdf',
+                'split_frequency': 'yearly',
+                'split_rule': 'random',
+                'url_pattern': 'https://cdaweb.gsfc.nasa.gov/pub/data/de/de1/particles_eics/vs_eics_cdaweb/{Y}/{y:02d}[0-3]\\d\\d_eics_de_96s_.*.cdf',
+                'use_file_list': True
+            },
+            "https://cdaweb.gsfc.nasa.gov/pub/data/de/de1/particles_eics/vs_eics_cdaweb/1986/86003_eics_de_96s_v01.cdf",
+            datetime(1986, 1, 3, tzinfo=timezone.utc)
+        ),
+        (
             "bar_1b_l2_fspc_%Y%m%d_%Q.cdf",
             "None",
             "https://cdaweb.gsfc.nasa.gov/pub/data/barrel/l2/1b/fspc",

--- a/tests/test_cdaweb_netcdf_direct_archive.py
+++ b/tests/test_cdaweb_netcdf_direct_archive.py
@@ -19,7 +19,7 @@ from unittest.mock import patch
 from ddt import data, ddt
 
 from speasy.core.codecs import get_codec
-from speasy.data_providers.cda import _archive_params_for
+from speasy.data_providers.cda import _archive_params_for, _codec_can_read
 from speasy.data_providers.cda._direct_archive import to_direct_archive_params
 
 try:
@@ -153,6 +153,49 @@ class TestNetCDFDatasetsAreProbedBeforeServingFiles(unittest.TestCase):
     def test_single_file_dataset_whose_file_is_missing_falls_back_to_the_web_service(self):
         self.assertIsNone(self._params_for('something_else.nc', '2018-10-05', '2018-10-06',
                                            file_naming='the_whole_mission.nc'))
+
+
+@unittest.skipIf(netCDF4 is None, "netCDF4 not installed")
+class TestProbeVerdictsAreRemembered(unittest.TestCase):
+    """Probing downloads and decodes a real file, so the answer is kept for a week -- but only
+    when it is an answer about the dataset. A file that could not be reached says nothing about
+    it, and remembering that for a week would keep a perfectly readable dataset on the REST API
+    long after the outage ended.
+    """
+
+    def setUp(self):
+        _codec_can_read.drop_entries()
+
+    def tearDown(self):
+        _codec_can_read.drop_entries()
+
+    def test_a_readable_file_is_not_decoded_twice(self):
+        with patch.object(get_codec('nc'), 'load_variable', return_value=object()) as load_variable:
+            self.assertTrue(_codec_can_read('file:///probe_readable.nc', 'nc', 'DENSITY'))
+            self.assertTrue(_codec_can_read('file:///probe_readable.nc', 'nc', 'DENSITY'))
+        self.assertEqual(load_variable.call_count, 1)
+
+    def test_a_file_the_codec_chokes_on_is_not_decoded_twice(self):
+        with patch.object(get_codec('nc'), 'load_variable',
+                          side_effect=AttributeError("NetCDF: Attribute not found")):
+            self.assertFalse(_codec_can_read('file:///probe_broken.nc', 'nc', 'DENSITY'))
+        with patch.object(get_codec('nc'), 'load_variable', return_value=object()) as load_variable:
+            self.assertFalse(_codec_can_read('file:///probe_broken.nc', 'nc', 'DENSITY'))
+            load_variable.assert_not_called()
+
+    def test_an_unreachable_file_is_not_remembered_as_a_verdict(self):
+        with patch.object(get_codec('nc'), 'load_variable', side_effect=IOError("connection reset")):
+            with self.assertRaises(IOError):
+                _codec_can_read('file:///probe_unreachable.nc', 'nc', 'DENSITY')
+        with patch.object(get_codec('nc'), 'load_variable', return_value=object()) as load_variable:
+            self.assertTrue(_codec_can_read('file:///probe_unreachable.nc', 'nc', 'DENSITY'))
+            load_variable.assert_called_once()
+
+    def test_each_variable_of_a_file_gets_its_own_verdict(self):
+        with patch.object(get_codec('nc'), 'load_variable', return_value=object()) as load_variable:
+            _codec_can_read('file:///probe_per_variable.nc', 'nc', 'DENSITY')
+            _codec_can_read('file:///probe_per_variable.nc', 'nc', 'TEMPERATURE')
+        self.assertEqual(load_variable.call_count, 2)
 
 
 if __name__ == '__main__':

--- a/tests/test_codec_coordinate_grids.py
+++ b/tests/test_codec_coordinate_grids.py
@@ -104,6 +104,15 @@ class CoordinateGridsSurviveANetCdfRoundTrip(unittest.TestCase):
         self.assertListEqual([ax.shape for ax in back.axes], [ax.shape for ax in var.axes])
 
     @data(coordinate_grids, record_varying_grid, plain_spectrogram)
+    def test_time_dependence_is_preserved(self, ctor):
+        # same trap as the CDF round trip above, and the likelier of the two to fall into it:
+        # NetCDF has no record-variance flag of its own, so DEPEND_0 is all that carries it
+        var = ctor()
+        back = _round_trip('nc', var)
+        self.assertListEqual([ax.is_time_dependent for ax in back.axes],
+                             [ax.is_time_dependent for ax in var.axes])
+
+    @data(coordinate_grids, record_varying_grid, plain_spectrogram)
     def test_values_are_preserved(self, ctor):
         var = ctor()
         back = _round_trip('nc', var)

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -159,6 +159,57 @@ class DirectArchiveDownloader(unittest.TestCase):
                                         'data_20180101_v01.cdf',   # v02 exists but listing is cached
                                         'data_20180101_v02.cdf'])  # force_refresh re-lists
 
+    def _randomly_split_request(self, server, file_reader):
+        return dict(url_pattern=server.url + r"/{Y}/data_\d+_v\d+\.cdf",
+                    split_rule='random', split_frequency='yearly', variable='B',
+                    start_time='2018-01-01', stop_time='2018-01-02',
+                    fname_regex=r"data_(?P<start>\d+)_v(?P<version>\d+)\.cdf",
+                    date_format="%Y%m%d", file_reader=file_reader)
+
+    def test_force_refresh_refreshes_the_file_listing_of_a_randomly_split_dataset(self):
+        # force_refresh re-ran map_ranges but not the file listing it is built from, so the retry
+        # a 404 triggers -- there to pick up files renamed by a fresh release -- kept resolving
+        # the names listed up to 12h earlier.
+        with tempfile.TemporaryDirectory() as archive:
+            os.makedirs(os.path.join(archive, '2018'))
+            open(os.path.join(archive, '2018', 'data_20180101_v01.cdf'), 'w').close()
+            server = _LocalHttpArchive(archive)
+            self.addCleanup(server.close)
+
+            resolved = []
+
+            def record_url(url, variable, **kwargs):
+                resolved.append(url.rsplit('/', 1)[-1])
+                return None
+
+            request = self._randomly_split_request(server, record_url)
+            get_product(**request)
+            open(os.path.join(archive, '2018', 'data_20180101_v02.cdf'), 'w').close()
+            get_product(**request)
+            get_product(**request, force_refresh=True)
+
+        self.assertListEqual(resolved, ['data_20180101_v01.cdf',   # only version published yet
+                                        'data_20180101_v01.cdf',   # v02 exists but listing is cached
+                                        'data_20180101_v02.cdf'])  # force_refresh re-lists
+
+    def test_force_refresh_reaches_the_file_reader_of_a_randomly_split_dataset(self):
+        # the file reader caches what it decodes too, so it has to be told to refresh as well.
+        with tempfile.TemporaryDirectory() as archive:
+            os.makedirs(os.path.join(archive, '2018'))
+            open(os.path.join(archive, '2018', 'data_20180101_v01.cdf'), 'w').close()
+            server = _LocalHttpArchive(archive)
+            self.addCleanup(server.close)
+
+            seen = []
+
+            def record_kwargs(url, variable, **kwargs):
+                seen.append(kwargs.get('force_refresh', False))
+                return None
+
+            get_product(**self._randomly_split_request(server, record_kwargs), force_refresh=True)
+
+        self.assertListEqual(seen, [True])
+
     def _burst_folder_values(self, file_names, fname_regex, values_per_file):
         """Serves a burst folder and returns the values get_product() settled on."""
 

--- a/tests/test_direct_archive_downloader.py
+++ b/tests/test_direct_archive_downloader.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from datetime import datetime, timezone
 from multiprocessing import Pool
 from ddt import ddt, data, unpack
 import numpy as np
@@ -46,6 +47,12 @@ def _custom_cdf_loader(url, variable, *args, **kwargs):
 class DirectArchiveDownloader(unittest.TestCase):
     def setUp(self):
         pass
+
+    def test_fills_the_two_digit_year_placeholder(self):
+        # CDAWeb spells two-digit years as %y, which becomes a {y:02d} field in the URL pattern.
+        self.assertEqual(dad.apply_date_format('{y:02d}{j:03d}', datetime(1986, 1, 3, tzinfo=timezone.utc)),
+                         '86003')
+        self.assertEqual(dad.apply_date_format('{y:02d}', datetime(2009, 1, 1, tzinfo=timezone.utc)), '09')
 
     def test_split_rules(self):
         self.assertListEqual(dad.spilt_range(split_frequency='daily', start_time='2010-01-01', stop_time='2010-01-01'),

--- a/tests/test_direct_archive_inventory.py
+++ b/tests/test_direct_archive_inventory.py
@@ -3,13 +3,16 @@ import io
 import os
 import tempfile
 import unittest
+import unittest.mock
 
 import numpy as np
 import yaml
 
 __HERE__ = os.path.dirname(os.path.abspath(__file__))
 
-from speasy.core.cdf.inventory_extractor import extract_parameter, make_dataset_index, extract_from_master
+import speasy.core.cdf.inventory_extractor as inventory_extractor
+from speasy.core.cdf.inventory_extractor import extract_parameter, extract_parameters, make_dataset_index, \
+    extract_from_master
 from speasy.core.codecs.codec_interface import CodecInterface
 from speasy.core.codecs.codecs_registry import register_codec
 from speasy.core.inventory.indexes import SpeasyIndex, DatasetIndex
@@ -332,6 +335,25 @@ class TestExtractParameterFailureReporting(unittest.TestCase):
             with self.assertLogs('speasy.core.cdf.inventory_extractor', level='WARNING'):
                 extract_parameter(self._UnreadableLoader(), "B_field", provider="archive")
         self.assertEqual(printed.getvalue(), "")
+
+    def test_logs_the_reason_a_whole_file_could_not_be_read(self):
+        class _UnlistableLoader:
+            def data_variables(self):
+                raise RuntimeError("broken file")
+
+        with self.assertLogs('speasy.core.cdf.inventory_extractor', level='WARNING') as captured:
+            self.assertListEqual(extract_parameters(_UnlistableLoader(), provider="archive"), [])
+        self.assertIn("broken file", captured.output[0])
+
+    def test_logs_the_reason_a_master_could_not_be_read(self):
+        with tempfile.NamedTemporaryFile(suffix='.cdf', delete=False) as f:
+            f.write(b"not a master at all")
+        self.addCleanup(os.unlink, f.name)
+        with unittest.mock.patch.object(inventory_extractor.pyistp, 'load',
+                                        side_effect=RuntimeError("broken master")):
+            with self.assertLogs('speasy.core.cdf.inventory_extractor', level='WARNING') as captured:
+                self.assertIsNone(extract_from_master(f.name, provider="archive", disable_cache=True))
+        self.assertIn("broken master", captured.output[0])
 
 
 class TestLoadInventoryFile(unittest.TestCase):

--- a/tests/test_direct_archive_inventory.py
+++ b/tests/test_direct_archive_inventory.py
@@ -1,3 +1,5 @@
+import contextlib
+import io
 import os
 import tempfile
 import unittest
@@ -7,7 +9,7 @@ import yaml
 
 __HERE__ = os.path.dirname(os.path.abspath(__file__))
 
-from speasy.core.cdf.inventory_extractor import make_dataset_index, extract_from_master
+from speasy.core.cdf.inventory_extractor import extract_parameter, make_dataset_index, extract_from_master
 from speasy.core.codecs.codec_interface import CodecInterface
 from speasy.core.codecs.codecs_registry import register_codec
 from speasy.core.inventory.indexes import SpeasyIndex, DatasetIndex
@@ -306,6 +308,30 @@ class TestMakeDatasetIndex(unittest.TestCase):
         built_parameters = [v for v in dataset.__dict__.values() if hasattr(v, 'spz_name')]
         self.assertGreater(len(built_parameters), 0)
 
+
+
+class TestExtractParameterFailureReporting(unittest.TestCase):
+    """A variable an inventory build cannot read is reported to the logs, with what went wrong.
+
+    It used to be printed to stdout instead, which a library cannot filter, silence or route,
+    and the exception was dropped on the way, leaving only the name behind.
+    """
+
+    class _UnreadableLoader:
+        def data_variable(self, var_name):
+            raise RuntimeError("broken variable")
+
+    def test_logs_the_reason_a_variable_could_not_be_read(self):
+        with self.assertLogs('speasy.core.cdf.inventory_extractor', level='WARNING') as captured:
+            self.assertIsNone(extract_parameter(self._UnreadableLoader(), "B_field", provider="archive"))
+        self.assertIn("B_field", captured.output[0])
+        self.assertIn("broken variable", captured.output[0])
+
+    def test_does_not_print_the_failure(self):
+        with contextlib.redirect_stdout(io.StringIO()) as printed:
+            with self.assertLogs('speasy.core.cdf.inventory_extractor', level='WARNING'):
+                extract_parameter(self._UnreadableLoader(), "B_field", provider="archive")
+        self.assertEqual(printed.getvalue(), "")
 
 
 class TestLoadInventoryFile(unittest.TestCase):

--- a/tests/test_hapi_codecs.py
+++ b/tests/test_hapi_codecs.py
@@ -1,5 +1,6 @@
 import contextlib
 from datetime import datetime
+import json
 import os
 import tempfile
 import unittest
@@ -15,7 +16,7 @@ import speasy.core.codecs.bundled_codecs.hapi.csv as hapi_csv
 import speasy.core.codecs.bundled_codecs.hapi.binary as hapi_binary
 from speasy.core.codecs.bundled_codecs.hapi.codec import _bin_to_axis
 from speasy.core.codecs.bundled_codecs.hapi.reader import _extract_headers
-from speasy.core.data_containers import VariableAxis
+from speasy.core.data_containers import DataContainer, VariableAxis, VariableTimeAxis
 from speasy.products import SpeasyVariable
 
 __HERE__ = os.path.dirname(__file__)
@@ -31,6 +32,33 @@ def _temp_output(suffix):
     """
     with tempfile.TemporaryDirectory() as d:
         yield os.path.join(d, "output" + suffix)
+
+
+_HAPI_CSV_WITH_FILL_VALUES = """#{
+#"HAPI": "2.0",
+#"status": {"code": 1200, "message": "OK"},
+#"format": "csv",
+#"parameters": [
+#{
+#"name": "Time",
+#"type": "isotime",
+#"units": "UTC",
+#"length":24,
+#"fill": null
+#},
+#{
+#"name": "Magnitude",
+#"type": "double",
+#"units": "nT",
+#"fill": "-1.0E31",
+#"description": "B-field magnitude"
+#}
+#]
+#}
+1997-09-02T00:00:00.000Z,2.658
+1997-09-02T01:00:00.000Z,-1.0E31
+1997-09-02T02:00:00.000Z,3.935
+"""
 
 
 @ddt
@@ -149,6 +177,35 @@ class TestHapiCsvCodec(unittest.TestCase):
         self.assertFalse(v_axis.is_time_dependent)
         self.assertEqual(v_axis.shape, (4,))
         self.assertEqual(v_axis.unit, "MeV")
+
+    def test_reads_the_fill_value_from_the_headers(self):
+        hapi_csv_codec: CodecInterface = get_codec('hapi/csv')
+        filepath = os.path.join(__HERE__, 'resources', 'HAPI_sample_csv.csv')
+        v: SpeasyVariable = hapi_csv_codec.load_variable(file=filepath, variable='Magnitude', disable_cache=True)
+        self.assertEqual(v.fill_value, -1.0e31)
+
+    def test_masks_the_values_equal_to_the_fill_value(self):
+        hapi_csv_codec: CodecInterface = get_codec('hapi/csv')
+        with _temp_output('.csv') as filepath:
+            with open(filepath, 'w') as f:
+                f.write(_HAPI_CSV_WITH_FILL_VALUES)
+            v: SpeasyVariable = hapi_csv_codec.load_variable(file=filepath, variable='Magnitude',
+                                                             disable_cache=True)
+            self.assertTrue(np.isnan(v.replace_fillval_by_nan().values[1, 0]))
+            self.assertEqual(v.replace_fillval_by_nan().values[0, 0], 2.658)
+
+    def test_writes_the_fill_value_as_the_string_hapi_asks_for(self):
+        hapi_csv_codec: CodecInterface = get_codec('hapi/csv')
+        filepath = os.path.join(__HERE__, 'resources', 'HAPI_sample_csv.csv')
+        v = hapi_csv_codec.load_variable(file=filepath, variable='Magnitude', disable_cache=True)
+        with _temp_output('.csv') as output_csv_file:
+            hapi_csv_codec.save_variables(variables=[v], file=output_csv_file)
+            with open(output_csv_file, 'rb') as f:
+                written = _extract_headers(f)['parameters'][1]['fill']
+            self.assertIsInstance(written, str)
+            reloaded = hapi_csv_codec.load_variable(file=output_csv_file, variable='Magnitude',
+                                                    disable_cache=True)
+        self.assertEqual(reloaded.fill_value, -1.0e31)
 
     def test_spz_getdata_to_csv(self):
         hapi_csv_codec: CodecInterface = get_codec('hapi/csv')
@@ -314,6 +371,36 @@ class TestHapiBinaryCodec(unittest.TestCase):
             hapi_binary_file = hapi_binary_codec.save_variables(variables=[spz_var], file=output_binary_file)
             self.assertTrue(hapi_binary_file)
             self.assertTrue(os.path.exists(output_binary_file))
+
+    def test_reads_timestamps_longer_than_milliseconds(self):
+        # HAPI lets a server declare any ISO-8601 time length; microseconds make it 27 characters.
+        hapi_binary_codec: CodecInterface = get_codec('hapi/binary')
+        headers = {
+            "HAPI": "2.0", "status": {"code": 1200, "message": "OK"}, "format": "binary",
+            "parameters": [{"name": "Time", "type": "isotime", "units": "UTC", "length": 27, "fill": None},
+                           {"name": "Magnitude", "type": "double", "units": "nT", "fill": None}]
+        }
+        payload = b''.join(b'#' + line for line in json.dumps(headers).encode().splitlines(keepends=True))
+        payload += b'\n' + b"2020-01-01T00:00:00.123456Z" + np.float64(2.5).tobytes()
+        with _temp_output('.binary') as filepath:
+            with open(filepath, 'wb') as f:
+                f.write(payload)
+            v = hapi_binary_codec.load_variable(file=filepath, variable="Magnitude", disable_cache=True)
+        self.assertEqual(v.time[0], np.datetime64("2020-01-01T00:00:00.123456", 'ns'))
+
+    def test_integer_values_survive_a_round_trip(self):
+        hapi_binary_codec: CodecInterface = get_codec('hapi/binary')
+        counts = SpeasyVariable(
+            axes=[VariableTimeAxis(values=np.arange(np.datetime64("2020-01-01T00:00:00", 'ns'),
+                                                    np.datetime64("2020-01-01T00:00:05", 'ns'),
+                                                    np.timedelta64(1, 's')))],
+            values=DataContainer(np.arange(5, dtype=np.int32).reshape(-1, 1), name="counts"),
+            columns=["counts"])
+        with _temp_output('.binary') as output_binary_file:
+            hapi_binary_codec.save_variables(variables=[counts], file=output_binary_file)
+            reloaded = hapi_binary_codec.load_variables(file=output_binary_file, variables=["counts"],
+                                                        disable_cache=True)["counts"]
+        self.assertListEqual(reloaded.values.ravel().tolist(), list(range(5)))
 
     def test_save_time_varying_axis(self):
         hapi_binary_codec: CodecInterface = get_codec('hapi/binary')

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -74,6 +74,24 @@ class MplBackendColormap(unittest.TestCase):
         mesh = ax.collections[0]
         self.assertEqual(mesh.norm.vmax, 0)
 
+    def test_a_linear_scale_scales_from_its_zeros(self):
+        """Zeros are dropped before computing vmin because a log scale cannot place them, but a
+        linear scale can: dropping them there clips every zero-valued cell to the bottom colour.
+        """
+        x, y, z = self._xyz()
+        z[0, 0] = 0.
+        ax = Plot().colormap(x, y, z, logz=False)
+        self.assertEqual(ax.collections[0].norm.vmin, 0.)
+
+    def test_a_slice_of_zeros_gets_usable_bounds(self):
+        x, y, _ = self._xyz()
+        z = np.zeros((4, 5))
+        for logz in (True, False):
+            with self.subTest(logz=logz):
+                ax = Plot().colormap(x, y, z, logz=logz)
+                norm = ax.collections[0].norm
+                self.assertLessEqual(norm.vmin, norm.vmax)
+
 
 class FigureIsolationBetweenTests(unittest.TestCase):
     """No setUp/cleanup here on purpose: this documents the isolation the test suite as a


### PR DESCRIPTION
Audit of everything merged since v1.7.1 ahead of cutting 1.8.0. Every fix landed test-first: each reproducer was watched fail on unfixed code with the exact expected error before the fix was written, and the whole set was re-verified by transplanting the new tests onto pristine `main`, where all eleven fail.

## Crash

- **Two-digit year placeholders crashed `get_data()`** — `apply_date_format` passed `{y:02d}` a string, so any dataset naming its files with `%y` (e.g. `DE_VS_EICS`) raised `ValueError: Unknown format code 'd'` instead of returning data, and `BEST` could not fall back because only `IOError` is caught on that path.

## HAPI codec

- **Fill values never reached the variables**: HAPI spells the attribute `fill`, nothing mapped it to `FILLVAL`, so every HAPI-fetched variable had `fill_value=None` and masking, `sanitized(drop_fill_values=True)` and plotting silently did nothing — sentinels like `-1e31` passed for real data. It is now parsed into the parameter's own type on read and written back out as the string HAPI requires. (This closes the type-string inconsistency Copilot flagged on #283.)
- **Integer parameters were written as type `"int"`**, a spelling neither the HAPI spec nor our own binary reader knows — reading back a file we had just written failed on the record size. Now `"integer"`.
- **Binary timestamps were truncated to 24 characters** (millisecond width); servers declaring finer precision lost digits silently. The width now follows the declared `length`.

## Direct archive

- **`force_refresh` was inert end-to-end for randomly split datasets** (most CDAWeb CDF datasets): the file listing behind `map_ranges` was never refreshed — so the 404-retry meant to pick up renamed files re-read the same stale listing — and the flag was popped before reaching the file reader's cache. The regularly split path already did both correctly.

## Cache

- **A waiting thread treated a cached falsy value as a miss**: the post-wait path in `CacheCall` still used `or` where #315 had switched the other two paths to `is not None`, so `False`, `0`, `""` or an empty variable got recomputed by every loser — defeating deduplication on exactly the expensive calls that answer "nothing".

## Plotting

- **Linear colour maps clipped zero-valued cells** (zeros were excluded from `vmin` regardless of scale), and an all-zero slice produced inverted bounds that `LogNorm` rejects with `ValueError: Invalid vmin or vmax`.

## Also

- Inventory-extraction failures now go to the logs with the exception included, instead of bare `print()` calls a host application can neither silence nor route.
- Two coverage tests for the #333 probe: what `_codec_can_read` may remember for a week (a decode failure) versus what it must not (an unreachable file), and NetCDF record-variance round-trip. Both were verified to fail when the behaviour they pin is removed.
- The pre-warm listing call is imported as `list_remote_files` so it cannot be misread as recursion inside the identically named staticmethod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)