### PR TITLE
Discover codecs through PEP 621 entry points

### DIFF
--- a/docs/user/direct_archive/direct_archive.rst
+++ b/docs/user/direct_archive/direct_archive.rst
@@ -750,7 +750,10 @@ A plugin that raises, at import or during registration, is reported as a warning
 and skipped: it can never break ``import speasy``. Individual plugins can be
 turned off by listing their entry-point names in the ``SPEASY_CORE_DISABLED_PLUGINS``
 environment variable (or the ``disabled_plugins`` entry of the ``CORE`` config
-section).
+section) — with the example above, ``SPEASY_CORE_DISABLED_PLUGINS=my_format``
+disables that one plugin and nothing else. This is also the reason to split
+unrelated codecs across several named entry points rather than one ``register``
+that does everything: each name can then be disabled on its own.
 
 .. _ad_hoc_custom_reader:
 

--- a/docs/user/direct_archive/direct_archive.rst
+++ b/docs/user/direct_archive/direct_archive.rst
@@ -637,10 +637,12 @@ is loaded automatically the next time Speasy starts.
     placing a file you didn't write yourself in a codecs directory. Three consequences worth knowing
     before you write one:
 
-    1. **A broken codec file breaks** ``import speasy`` **for everyone**, not just archive datasets — a
-       syntax error, or a ``name``/extension/mimetype collision with another registered codec, crashes
-       at import time with an uncaught exception. Unlike a malformed YAML entry (which only costs that
-       one dataset), there's no per-codec error containment.
+    1. **A codec file that raises is logged as a warning and skipped**, not an error that breaks ``import speasy``.
+       When a codec file throws an exception (syntax error, name collision, etc.), Speasy logs a warning with the
+       file path and traceback, then continues loading other codecs. This means the error is contained — broken code
+       can never break ``import speasy``. Packaged entry-point codecs gain the same robustness (see
+       :ref:`shipping_a_codec_as_a_package` below) plus avoid gotchas 2 and 3 below, which are specific to the
+       ``exec()`` semantics of directory-based codec files.
     2. **Import codec/registry helpers from their submodules**, not the ``speasy.core.codecs`` package
        itself: ``from speasy.core.codecs.codec_interface import CodecInterface`` and
        ``from speasy.core.codecs.codecs_registry import register_codec``. Codec files load while that
@@ -712,6 +714,43 @@ inline ``variables:`` and ``master_file:`` discovery:
 Used from a YAML inventory entry as ``codec: mycsv`` (or ``codec: my_csv_codec``), either with a
 ``master_file:`` (thanks to ``list_variables``) or an inline ``variables:`` block, exactly like a
 built-in format.
+
+.. _shipping_a_codec_as_a_package:
+
+Shipping a codec as a package
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A codec can be distributed as a normal Python package: declare a ``speasy.codecs``
+entry point, and every environment that installs the package gets the codec
+registered automatically, with none of the import caveats that apply to codec
+files placed in the user directories.
+
+.. code-block:: toml
+
+   [project.entry-points."speasy.codecs"]
+   my_format = "my_pkg.speasy_codec:register"
+
+``register`` is a zero-argument callable that performs the registration; it may
+register as many codecs as it wants:
+
+.. code-block:: python
+
+   from speasy.core.codecs.codec_interface import CodecInterface
+   from speasy.core.codecs.codecs_registry import register_codec
+
+   def register():
+       register_codec(MyFormatCodec)
+       register_codec(MyOtherFormatCodec)
+
+The same package may also declare entry points for other Speasy plugin groups
+(for instance ``speasy.virtual_products``, once virtual products land) next to
+its codecs.
+
+A plugin that raises, at import or during registration, is reported as a warning
+and skipped: it can never break ``import speasy``. Individual plugins can be
+turned off by listing their entry-point names in the ``SPEASY_CORE_DISABLED_PLUGINS``
+environment variable (or the ``disabled_plugins`` entry of the ``CORE`` config
+section).
 
 .. _ad_hoc_custom_reader:
 

--- a/docs/user/direct_archive/direct_archive.rst
+++ b/docs/user/direct_archive/direct_archive.rst
@@ -751,7 +751,9 @@ and skipped: it can never break ``import speasy``. Individual plugins can be
 turned off by listing their entry-point names in the ``SPEASY_CORE_DISABLED_PLUGINS``
 environment variable (or the ``disabled_plugins`` entry of the ``CORE`` config
 section) — with the example above, ``SPEASY_CORE_DISABLED_PLUGINS=my_format``
-disables that one plugin and nothing else. This is also the reason to split
+disables that one plugin and nothing else. A bare name is matched in every
+plugin group; to disable a plugin in one group only, qualify the name with its
+group, e.g. ``speasy.codecs.my_format``. This is also the reason to split
 unrelated codecs across several named entry points rather than one ``register``
 that does everything: each name can then be disabled on its own.
 

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -191,7 +191,8 @@ This is useful to avoid creating a new pool for each request.""",
                      disabled_plugins={"default": "",
                                        "description": """A comma separated list of plugin entry-point names to skip, e.g. the
 'my_format' of [project.entry-points."speasy.codecs"] my_format = "my_pkg:register".
-Each name disables that single plugin; names are matched in every plugin group.""",
+A bare name disables that plugin in every group; a group-qualified name such as
+'speasy.codecs.my_format' disables it in that group only.""",
                                        "type_ctor": _parse_dir_set},
                      )
 

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -188,6 +188,10 @@ This is useful to avoid creating a new pool for each request.""",
                      user_codecs_extra_dirs={"default": "",
                                              "description": """A comma separated list of directories to scan for extra codecs.""",
                                              "type_ctor": _parse_dir_set},
+                     disabled_plugins={"default": "",
+                                       "description": """A comma separated list of plugin entry-point names to skip
+(any group, e.g. speasy.codecs).""",
+                                       "type_ctor": _parse_dir_set},
                      )
 
 proxy = ConfigSection("PROXY",

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -189,8 +189,9 @@ This is useful to avoid creating a new pool for each request.""",
                                              "description": """A comma separated list of directories to scan for extra codecs.""",
                                              "type_ctor": _parse_dir_set},
                      disabled_plugins={"default": "",
-                                       "description": """A comma separated list of plugin entry-point names to skip
-(any group, e.g. speasy.codecs).""",
+                                       "description": """A comma separated list of plugin entry-point names to skip, e.g. the
+'my_format' of [project.entry-points."speasy.codecs"] my_format = "my_pkg:register".
+Each name disables that single plugin; names are matched in every plugin group.""",
                                        "type_ctor": _parse_dir_set},
                      )
 

--- a/speasy/core/codecs/__init__.py
+++ b/speasy/core/codecs/__init__.py
@@ -1,6 +1,10 @@
 from .codec_interface import CodecInterface, Buffer
-from .codecs_registry import register_codec, get_codec, user_codecs_dir
+from .codecs_registry import register_codec, get_codec, user_codecs_dir, load_extra_codecs
 
 __all__ = ['CodecInterface', 'register_codec', 'get_codec', 'user_codecs_dir']
 
 from . import bundled_codecs
+from ..plugins import load_plugins
+
+load_extra_codecs()
+load_plugins("speasy.codecs")

--- a/speasy/core/codecs/codecs_registry.py
+++ b/speasy/core/codecs/codecs_registry.py
@@ -1,8 +1,11 @@
 from typing import Optional
 from .codec_interface import CodecInterface
 from speasy.config import core as cfg
+import logging
 import os
 import appdirs
+
+log = logging.getLogger(__name__)
 
 __USER_CODECS_DIR__ = f'{appdirs.user_data_dir("speasy", "LPP")}/codecs'
 
@@ -62,7 +65,10 @@ def _list_dir_abs(path: str):
 
 def _load_codec(path: str):
     if path.endswith('.py'):
-        exec(open(os.path.join(path, path)).read())
+        try:
+            exec(open(path).read())
+        except Exception:
+            log.warning(f"Failed to load codec file {path}", exc_info=True)
 
 
 def load_extra_codecs():
@@ -71,9 +77,6 @@ def load_extra_codecs():
     for path in cfg.user_codecs_extra_dirs.get():
         if os.path.exists(path):
             list(map(_load_codec, _list_dir_abs(path)))
-
-
-load_extra_codecs()
 
 
 def get_codec(codec: str) -> Optional[CodecInterface]:

--- a/speasy/core/codecs/codecs_registry.py
+++ b/speasy/core/codecs/codecs_registry.py
@@ -66,7 +66,8 @@ def _list_dir_abs(path: str):
 def _load_codec(path: str):
     if path.endswith('.py'):
         try:
-            exec(open(path).read())
+            with open(path) as codec_file:
+                exec(codec_file.read())
         except Exception:
             log.warning(f"Failed to load codec file {path}", exc_info=True)
 

--- a/speasy/core/plugins.py
+++ b/speasy/core/plugins.py
@@ -15,11 +15,12 @@ def load_plugins(group: str) -> None:
     Each entry point must resolve to a zero-argument callable that performs its own
     registration. A plugin that fails, to import or when called, is reported and skipped:
     third-party code must never break `import speasy`. Entry points named in the
-    `core.disabled_plugins` config entry are not loaded at all.
+    `core.disabled_plugins` config entry are not loaded at all, either by bare name
+    (every group) or by group-qualified name (that group only).
     """
     disabled = core_cfg.disabled_plugins.get()
     for ep in entry_points(group=group):
-        if ep.name in disabled:
+        if ep.name in disabled or f"{group}.{ep.name}" in disabled:
             log.info(f"Skipping disabled plugin {ep.name} ({ep.value})")
             continue
         try:

--- a/speasy/core/plugins.py
+++ b/speasy/core/plugins.py
@@ -1,0 +1,28 @@
+"""PEP 621 entry-point plugin loading, shared by every plugin group Speasy defines
+(codecs today, virtual products when they land)."""
+
+import logging
+from importlib.metadata import entry_points
+
+from speasy.config import core as core_cfg
+
+log = logging.getLogger(__name__)
+
+
+def load_plugins(group: str) -> None:
+    """Load and call every entry point declared in the group.
+
+    Each entry point must resolve to a zero-argument callable that performs its own
+    registration. A plugin that fails, to import or when called, is reported and skipped:
+    third-party code must never break `import speasy`. Entry points named in the
+    `core.disabled_plugins` config entry are not loaded at all.
+    """
+    disabled = core_cfg.disabled_plugins.get()
+    for ep in entry_points(group=group):
+        if ep.name in disabled:
+            log.info(f"Skipping disabled plugin {ep.name} ({ep.value})")
+            continue
+        try:
+            ep.load()()
+        except Exception:
+            log.warning(f"Failed to load plugin {ep.name} ({ep.value})", exc_info=True)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -214,14 +214,51 @@ class EntryPointCodecs(unittest.TestCase):
 
 class UserDirectoryCodecFailuresAreContained(unittest.TestCase):
 
+    _VALID_CODEC_FILE = '''\
+from speasy.core.codecs.codec_interface import CodecInterface
+from speasy.core.codecs.codecs_registry import register_codec
+
+
+@register_codec
+class _UserDirValidCodec(CodecInterface):
+
+    def load_variables(self, variables, file, cache_remote_files=True, **kwargs):
+        raise NotImplementedError
+
+    def load_variable(self, variable, file, cache_remote_files=True, **kwargs):
+        raise NotImplementedError
+
+    def save_variables(self, variables, file=None, **kwargs):
+        raise NotImplementedError
+
+    @property
+    def supported_extensions(self):
+        return ['udv']
+
+    @property
+    def supported_mimetypes(self):
+        return []
+
+    @property
+    def name(self):
+        return 'codec/user-dir-valid'
+'''
+
     def test_a_broken_codec_file_is_skipped_and_the_valid_one_still_loads(self):
         with tempfile.TemporaryDirectory() as codec_dir:
             with open(os.path.join(codec_dir, 'broken.py'), 'w') as f:
                 f.write("raise RuntimeError('this codec file is broken')\n")
             with open(os.path.join(codec_dir, 'valid.py'), 'w') as f:
-                f.write("VALID_CODEC_FILE_RAN = True\n")
-            with mock.patch.object(codecs_registry.cfg.user_codecs_extra_dirs, 'get',
-                                   return_value={codec_dir}):
-                with self.assertLogs('speasy.core.codecs.codecs_registry', level='WARNING') as captured:
-                    codecs_registry.load_extra_codecs()
-        self.assertIn('broken.py', captured.output[0])
+                f.write(self._VALID_CODEC_FILE)
+            try:
+                with mock.patch.object(codecs_registry, 'user_codecs_dir',
+                                       return_value='/nonexistent-speasy-user-codecs-dir'):
+                    with mock.patch.object(codecs_registry.cfg.user_codecs_extra_dirs, 'get',
+                                           return_value={codec_dir}):
+                        with self.assertLogs('speasy.core.codecs.codecs_registry', level='WARNING') as captured:
+                            codecs_registry.load_extra_codecs()
+                self.assertTrue(any('broken.py' in line for line in captured.output))
+                self.assertIsNotNone(get_codec('codec/user-dir-valid'))
+            finally:
+                codecs_registry.__CODECS__.pop('codec/user-dir-valid', None)
+                codecs_registry.__CODECS__.pop('udv', None)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -7,6 +7,9 @@ import unittest
 from ddt import ddt, data, unpack
 
 import os
+import tempfile
+from unittest import mock
+import numpy as np
 from speasy.core.codecs import get_codec
 
 __HERE__ = os.path.dirname(os.path.abspath(__file__))
@@ -130,3 +133,95 @@ class TestListVariables(unittest.TestCase):
         self.assertIsNotNone(codec)
         with self.assertRaises(NotImplementedError):
             codec.list_variables(f"{__HERE__}/resources/ac_k2_mfi_20220101_v03.cdf")
+
+
+from speasy.core.codecs import get_codec, CodecInterface
+from speasy.core.codecs import codecs_registry
+from speasy.core import plugins
+from speasy.products import DataContainer, SpeasyVariable, VariableTimeAxis
+
+
+class _TinyCodec(CodecInterface):
+    """Minimal codec used to prove registration paths; mirrors the test codec in
+    test_direct_archive_inventory.py."""
+
+    def list_variables(self, file):
+        return ['foo']
+
+    def load_variables(self, variables, file, cache_remote_files=True, **kwargs):
+        time = np.array(['2020-01-01'], dtype='datetime64[ns]')
+        var = SpeasyVariable(axes=[VariableTimeAxis(values=time)],
+                             values=DataContainer(values=np.array([1.0])))
+        return {v: var for v in variables}
+
+    def load_variable(self, variable, file, cache_remote_files=True, **kwargs):
+        return self.load_variables([variable], file, cache_remote_files, **kwargs).get(variable)
+
+    def save_variables(self, variables, file=None, **kwargs):
+        raise NotImplementedError
+
+    @property
+    def supported_extensions(self):
+        return ['tiny']
+
+    @property
+    def supported_mimetypes(self):
+        return []
+
+    @property
+    def name(self):
+        return 'codec/tiny-entry-point'
+
+
+class EntryPointCodecs(unittest.TestCase):
+
+    def _load_through_entry_point(self, register):
+        ep = mock.MagicMock()
+        ep.name = 'tiny'
+        ep.value = 'tiny_pkg:register'
+        ep.load.return_value = register
+        with mock.patch.object(plugins, 'entry_points', return_value=[ep]):
+            plugins.load_plugins('speasy.codecs')
+
+    def test_a_codec_shipped_through_an_entry_point_is_registered(self):
+        from speasy.core.codecs import register_codec
+        self._load_through_entry_point(lambda: register_codec(_TinyCodec))
+        try:
+            self.assertIsNotNone(get_codec('codec/tiny-entry-point'))
+            self.assertIsNotNone(get_codec('tiny'))
+        finally:
+            codecs_registry.__CODECS__.pop('codec/tiny-entry-point', None)
+            codecs_registry.__CODECS__.pop('tiny', None)
+
+    def test_a_codec_colliding_with_a_bundled_one_is_refused_and_reported(self):
+        from speasy.core.codecs import register_codec
+
+        class _Impostor(_TinyCodec):
+            @property
+            def supported_extensions(self):
+                return ['cdf']   # bundled ISTP codec already owns cdf
+
+            @property
+            def name(self):
+                return 'codec/impostor'
+
+        bundled = get_codec('cdf')
+        with self.assertLogs('speasy.core.plugins', level='WARNING'):
+            self._load_through_entry_point(lambda: register_codec(_Impostor))
+        codecs_registry.__CODECS__.pop('codec/impostor', None)  # name lands before the ext collision
+        self.assertIs(get_codec('cdf'), bundled)
+
+
+class UserDirectoryCodecFailuresAreContained(unittest.TestCase):
+
+    def test_a_broken_codec_file_is_skipped_and_the_valid_one_still_loads(self):
+        with tempfile.TemporaryDirectory() as codec_dir:
+            with open(os.path.join(codec_dir, 'broken.py'), 'w') as f:
+                f.write("raise RuntimeError('this codec file is broken')\n")
+            with open(os.path.join(codec_dir, 'valid.py'), 'w') as f:
+                f.write("VALID_CODEC_FILE_RAN = True\n")
+            with mock.patch.object(codecs_registry.cfg.user_codecs_extra_dirs, 'get',
+                                   return_value={codec_dir}):
+                with self.assertLogs('speasy.core.codecs.codecs_registry', level='WARNING') as captured:
+                    codecs_registry.load_extra_codecs()
+        self.assertIn('broken.py', captured.output[0])

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -58,6 +58,23 @@ class LoadPlugins(unittest.TestCase):
         with mock.patch.object(plugins, "entry_points", return_value=[]):
             plugins.load_plugins("speasy.virtual_products")
 
+    def test_a_group_qualified_name_disables_the_plugin_in_that_group(self):
+        disabled = _entry_point("my_format")
+        with mock.patch.object(plugins, "entry_points", return_value=[disabled]):
+            with mock.patch.object(plugins.core_cfg.disabled_plugins, "get",
+                                   return_value={"speasy.codecs.my_format"}):
+                plugins.load_plugins("speasy.codecs")
+        disabled.load.assert_not_called()
+
+    def test_a_name_qualified_with_another_group_does_not_disable_it_here(self):
+        target = mock.MagicMock()
+        homonym = _entry_point("my_format", target)
+        with mock.patch.object(plugins, "entry_points", return_value=[homonym]):
+            with mock.patch.object(plugins.core_cfg.disabled_plugins, "get",
+                                   return_value={"speasy.virtual_products.my_format"}):
+                plugins.load_plugins("speasy.codecs")
+        target.assert_called_once_with()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest import mock
+import unittest.mock as mock
 
 from speasy.core import plugins
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest import mock
+
+from speasy.core import plugins
+
+
+def _entry_point(name, target=None, load_error=None):
+    """A stand-in for importlib.metadata.EntryPoint: .name, .value, .load()."""
+    ep = mock.MagicMock()
+    ep.name = name
+    ep.value = f"{name}_pkg:register"
+    if load_error is not None:
+        ep.load.side_effect = load_error
+    else:
+        ep.load.return_value = target
+    return ep
+
+
+class LoadPlugins(unittest.TestCase):
+
+    def test_loads_and_calls_every_entry_point(self):
+        first, second = mock.MagicMock(), mock.MagicMock()
+        eps = [_entry_point("first", first), _entry_point("second", second)]
+        with mock.patch.object(plugins, "entry_points", return_value=eps) as entry_points:
+            plugins.load_plugins("speasy.codecs")
+        entry_points.assert_called_once_with(group="speasy.codecs")
+        first.assert_called_once_with()
+        second.assert_called_once_with()
+
+    def test_a_plugin_failing_to_load_does_not_stop_the_others(self):
+        survivor = mock.MagicMock()
+        eps = [_entry_point("broken", load_error=ImportError("missing dep")),
+               _entry_point("survivor", survivor)]
+        with mock.patch.object(plugins, "entry_points", return_value=eps):
+            with self.assertLogs("speasy.core.plugins", level="WARNING") as captured:
+                plugins.load_plugins("speasy.codecs")
+        survivor.assert_called_once_with()
+        self.assertIn("broken", captured.output[0])
+
+    def test_a_plugin_raising_when_called_does_not_stop_the_others(self):
+        survivor = mock.MagicMock()
+        eps = [_entry_point("raises", mock.MagicMock(side_effect=ValueError("collision"))),
+               _entry_point("survivor", survivor)]
+        with mock.patch.object(plugins, "entry_points", return_value=eps):
+            with self.assertLogs("speasy.core.plugins", level="WARNING") as captured:
+                plugins.load_plugins("speasy.codecs")
+        survivor.assert_called_once_with()
+        self.assertIn("raises", captured.output[0])
+
+    def test_a_disabled_plugin_is_never_loaded(self):
+        disabled = _entry_point("unwanted")
+        with mock.patch.object(plugins, "entry_points", return_value=[disabled]):
+            with mock.patch.object(plugins.core_cfg.disabled_plugins, "get", return_value={"unwanted"}):
+                plugins.load_plugins("speasy.codecs")
+        disabled.load.assert_not_called()
+
+    def test_an_empty_group_is_a_no_op(self):
+        with mock.patch.object(plugins, "entry_points", return_value=[]):
+            plugins.load_plugins("speasy.virtual_products")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Retrofit of the plugin-discovery design settled in #186, applied to codecs ahead of 1.8.0. Third-party packages can now ship Speasy codecs as normal pip installs:

```toml
[project.entry-points."speasy.codecs"]
my_format = "my_pkg.speasy_codec:register"
```

`register` is a zero-argument callable that performs the registration; one callable may register any number of codecs, and a package may declare entry points in several groups at once (`speasy.virtual_products` will use the same loader when #186 lands).

## What changed

- **New generic loader `speasy/core/plugins.py`** — `load_plugins(group)` iterates `importlib.metadata.entry_points(group=...)`, skips names listed in the new `SPEASY_CORE_DISABLED_PLUGINS` setting, and wraps each entry point's load-and-call individually: a plugin that raises is reported with its traceback and skipped. Third-party code can never break `import speasy`.
- **Explicit codec load order** — the registry no longer self-loads at import; `speasy/core/codecs/__init__.py` orchestrates bundled → user directories → entry points. Bundled codecs always register first and win collisions; previously a user codec colliding with a bundled name crashed at the *bundled* registration, where no containment could reach.
- **Broken user-directory codec files warn and skip** instead of crashing `import speasy` for everyone — the remaining files still load. (This also fixes `_load_codec` opening `os.path.join(path, path)`, which only worked because `join` discards the first component when the second is absolute.)
- **Docs** — the custom-codec guide gains a "Shipping a codec as a package" section; the import-crash gotcha is rewritten to the new behaviour, with a note that the exec()-related gotchas don't apply to packaged codecs (the main reason to prefer packaging).

Entirely offline test coverage (mocked entry points, temp-dir codec files); the containment and integration tests were mutation-checked — each verified to fail when the behaviour it pins is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)