### PR TITLE
Fix WASM CI: install stable Chrome instead of a Chromium snapshot

### DIFF
--- a/.github/workflows/wasm_tests.yml
+++ b/.github/workflows/wasm_tests.yml
@@ -73,6 +73,14 @@ jobs:
         # left chromedriver several majors ahead of the Chrome the runner image ships
         browser-version: stable
 
+    - name: Point the runner's system Chrome at the one chromedriver matches
+      # install-browser symlinks /usr/bin/google-chrome and /usr/bin/chromedriver at the
+      # Chrome it installed, but the runner image ships another Chrome at
+      # /opt/google/chrome/chrome, and that is the binary Selenium Manager resolves --
+      # leaving chromedriver refusing a browser a major or more off. Point that path at the
+      # same binary so both resolutions agree whatever the runner image happens to ship.
+      run: sudo ln -sf "$(readlink -f /usr/bin/google-chrome)" /opt/google/chrome/chrome
+
     - name: install pyodide-py
       run: |
         python -m pip install pyodide-py==0.29.0

--- a/.github/workflows/wasm_tests.yml
+++ b/.github/workflows/wasm_tests.yml
@@ -40,16 +40,7 @@ jobs:
     - name: Install Node.js
       uses: actions/setup-node@v7
       with:
-        node-version: latest
-    - name: Cache Playwright Browsers
-      uses: actions/cache@v6
-      with:
-          path: .cache/ms-playwright
-          key: ${{ runner.os }}-playwright-latest
-
-    - name: Install Playwright Browsers
-      run: pip install playwright && python -m playwright install --with-deps
-
+        node-version: '24'
 #    - name: Download pyodide wheel artifact
 #      uses: pyodide/pyodide-actions/download-pyodide@v2
 #      with:
@@ -78,14 +69,16 @@ jobs:
       with:
         runner: selenium
         browser: chrome
-        browser-version: latest
+        # 'latest' means the newest *Chromium snapshot*, not the newest stable Chrome, and
+        # left chromedriver several majors ahead of the Chrome the runner image ships
+        browser-version: stable
 
     - name: install pyodide-py
       run: |
         python -m pip install pyodide-py==0.29.0
 
     - name: Install pytest-pyodide
-      run: python -m pip install pytest-pyodide
+      run: python -m pip install pytest-pyodide==0.59.2
 
     - name: Run tests
       run: |


### PR DESCRIPTION
The WASM job has failed on every run since 2026-08-17 (first red: `3f3bfc7` on a dependabot branch) with:

```
session not created: This version of ChromeDriver only supports Chrome version 154.
Current browser version is 151.0.7922.137 with binary path /opt/google/chrome/chrome
```

**Result: WASM job green again, 5 passed — and down from ~29 min to 1 min 32 s.**

## Root cause: browser resolution, not version drift

The job ends up with several Chromes on the box. `install-browser` overwrites `/usr/bin/google-chrome` and `/usr/bin/chromedriver` to point at the pair it installs — but the runner image ships another Chrome at `/opt/google/chrome/chrome`, and **that** is the binary Selenium Manager resolves. `pytest-pyodide` builds its driver as `Chrome(options=options)` with no `Service` and no `binary_location`, so Selenium Manager resolves both ends independently: driver from PATH, browser from the system install. ChromeDriver then refuses the mismatch.

This was established empirically, not inferred. An intermediate commit on this branch switched `browser-version` to `stable` on the theory that matching majors would make the resolution moot — it doesn't, because the runner image lags a major behind Chrome for Testing. That run is the proof: with chromedriver **152** *and* a matching Chrome 152 already symlinked onto `/usr/bin/google-chrome`, Selenium Manager still went to `/opt/google/chrome/chrome` (151). No version-alignment strategy can fix this, because the resolver ignores the aligned pair in front of it.

The fix points that path at the same binary:

```yaml
- run: sudo ln -sf "$(readlink -f /usr/bin/google-chrome)" /opt/google/chrome/chrome
```

Symlinked rather than deleted deliberately: with no browser found at all, Selenium Manager falls back to downloading one, which would put the version back in play by another route.

## On the original trigger

The Chromium snapshot bump was **not** it: snapshot 153 passed on 08-06 and snapshot 153 failed on 08-17. Two things changed in between — `selenium 4.46.0 → 4.47.0` and the runner image `20260720.247.2 → 20260810.271.1` — and the logs cannot separate them. The fix makes both moot, so that bisect was not run, and no selenium pin is added.

## Also in this job

- **`browser-version: latest` → `stable`.** Not the fix, but per [setup-chrome's version formats](https://github.com/browser-actions/setup-chrome#supported-version-formats) `latest` means the newest **Chromium snapshot**, while the channel names come from Chrome for Testing. A proper release is a better thing to test against than a bleeding-edge dev build.
- **Dropped the playwright browser install.** The tests run `--runner=selenium`, so the downloaded Chromium, Firefox, WebKit and FFmpeg were never used — and the step cost **27m57s of a 29m job**. The playwright *package* is still installed, as a hard dependency of `pytest-pyodide`.
- **Dropped its cache step with it.** It cached `.cache/ms-playwright` (workspace-relative) while playwright writes to `~/.cache/ms-playwright`, so every run logged `Cache not found for input keys: Linux-playwright-latest` and re-downloaded everything. The key had no version in it either, so it could never have invalidated.
- **Pinned the remaining floating inputs**, `node-version` and `pytest-pyodide`, matching the `pyodide-py==0.29.0` pin already in this job.

Branched off `main` — this is pre-existing and independent of #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)