### PR TITLE
Give Windows CI the same TCP connect patience as Linux

### DIFF
--- a/.github/workflows/PRs.yml
+++ b/.github/workflows/PRs.yml
@@ -24,6 +24,33 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+    - name: Give Windows the same TCP connect patience as Linux
+      if: runner.os == 'Windows'
+      shell: pwsh
+      # Windows abandons an unanswered TCP connect far sooner than the other
+      # platforms, whatever timeout the application asked for. Measured on these
+      # runners by timing a connect to a blackholed address:
+      #
+      #   MaxSynRetransmissions = 2   ->    7.0 s
+      #   MaxSynRetransmissions = 4   ->   21.0 s   (what the runners ship)
+      #   MaxSynRetransmissions = 6   ->  123.0 s
+      #   MaxSynRetransmissions = 8   ->  >150 s
+      #   MaxSynRetransmissions = 10  ->  rejected, "the parameter is incorrect"
+      #
+      # against macOS at 75.0 s and Linux at 135.5 s. Only Windows quits inside
+      # speasy's own 60 s timeout, which is why network tests fail there and not
+      # elsewhere. 6 puts the ceiling at 123 s -- past the 60 s budget with room,
+      # next to Linux, and clear of the values the stack refuses.
+      #
+      # Do not trust the published 3s-doubling arithmetic here: it predicts 21 s
+      # at 2 (measured 7) and 31 s at 4 (measured 21). These numbers are measured.
+      run: |
+        foreach ($s in Get-NetTCPSetting | Where-Object { $_.SettingName -ne 'Automatic' }) {
+          Set-NetTCPSetting -SettingName $s.SettingName -MaxSynRetransmissions 6
+        }
+        $applied = (Get-NetTCPSetting -SettingName InternetCustom).MaxSynRetransmissions
+        if ($applied -ne 6) { throw "MaxSynRetransmissions is $applied, expected 6" }
+        Write-Host "MaxSynRetransmissions = $applied (connect ceiling ~123s)"
     - name: add test logins
       uses: extractions/netrc@v3
       with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,33 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
+    - name: Give Windows the same TCP connect patience as Linux
+      if: runner.os == 'Windows'
+      shell: pwsh
+      # Windows abandons an unanswered TCP connect far sooner than the other
+      # platforms, whatever timeout the application asked for. Measured on these
+      # runners by timing a connect to a blackholed address:
+      #
+      #   MaxSynRetransmissions = 2   ->    7.0 s
+      #   MaxSynRetransmissions = 4   ->   21.0 s   (what the runners ship)
+      #   MaxSynRetransmissions = 6   ->  123.0 s
+      #   MaxSynRetransmissions = 8   ->  >150 s
+      #   MaxSynRetransmissions = 10  ->  rejected, "the parameter is incorrect"
+      #
+      # against macOS at 75.0 s and Linux at 135.5 s. Only Windows quits inside
+      # speasy's own 60 s timeout, which is why network tests fail there and not
+      # elsewhere. 6 puts the ceiling at 123 s -- past the 60 s budget with room,
+      # next to Linux, and clear of the values the stack refuses.
+      #
+      # Do not trust the published 3s-doubling arithmetic here: it predicts 21 s
+      # at 2 (measured 7) and 31 s at 4 (measured 21). These numbers are measured.
+      run: |
+        foreach ($s in Get-NetTCPSetting | Where-Object { $_.SettingName -ne 'Automatic' }) {
+          Set-NetTCPSetting -SettingName $s.SettingName -MaxSynRetransmissions 6
+        }
+        $applied = (Get-NetTCPSetting -SettingName InternetCustom).MaxSynRetransmissions
+        if ($applied -ne 6) { throw "MaxSynRetransmissions is $applied, expected 6" }
+        Write-Host "MaxSynRetransmissions = $applied (connect ceiling ~123s)"
     - name: add test logins
       uses: extractions/netrc@v3
       with:


### PR DESCRIPTION
Network tests fail on Windows runners and not on Linux or macOS — `test_hapi.py::TestHapiClient::test_build_url` most often, but also `test_cdaweb.py::test_get_variable_ws_4` and `test_zzz_disable_ws.py::test_disable_ssc_and_cda` on main's scheduled runs. It is intermittent, and it is not a Windows *connectivity* problem: it is a timeout constant.

## Windows gives up before the application asks it to

speasy configures a 60 s timeout. Windows abandons an unanswered TCP connect long before that, whatever the application requested. Measured on the actual runners by timing a connect to a blackholed address with a 150 s socket timeout — anything finishing sooner means the OS quit on its own, so the elapsed time *is* the ceiling:

| `MaxSynRetransmissions` | connect ceiling |
|---|---|
| 2 | 7.0 s |
| **4 — what the runners ship** | **21.0 s** |
| **6** | **123.0 s** ← this PR |
| 8 | >150 s |
| 10 | rejected: *"the parameter is incorrect"* |

## Why this is the whole difference between the platforms

urllib3 retries 5 times. What bounds each attempt is whichever limit is lower — the OS ceiling or speasy's 60 s:

| | OS ceiling | bounds an attempt | 5 retries span | fails in CI? |
|---|---|---|---|---|
| Linux | 135.5 s (`tcp_syn_retries=6`) | app, 60 s | ~5 min | no |
| macOS | 75.0 s (`keepinit=75000`) | app, 60 s | ~5 min | no |
| **Windows today** | **21.0 s** | **OS, 21 s** | **~2 min** | **yes** |
| Windows with this PR | 123 s | app, 60 s | ~5 min | — |

Windows is the only platform whose kernel quits *inside* the application's own timeout, so it gets less than half the retry budget of the platforms that pass. This PR does not hand Windows extra patience — it gives it **exactly the budget Linux and macOS already run successfully**.

That is also the evidence that the budget suffices: if drop episodes were long enough to exhaust 5 × 60 s, Linux would be failing too, and it is not.

## The change

Sets `MaxSynRetransmissions = 6` on Windows runners in both workflows, then **reads the value back and throws if it did not apply**. That guard is not decorative: it is how `MaxSynRetransmissions = 10` was caught being refused outright by the TCP stack, and how an earlier revision of this PR was caught being a **no-op** — it set the value to 4, which is what the runners already ship.

The measurements are recorded in the step comment, with a warning not to trust the published 3 s-doubling arithmetic: it predicts 21 s at `2` (measured **7**) and 31 s at `4` (measured **21**), so it does not describe these hosts.

## Scope and residual risk

This equalises client behaviour. It does **not** address the server side: something at IRAP's `proxy4` (in front of `amda.irap.omp.eu`) silently drops SYNs in multi-minute episodes — drops, not refusals, since a closed port surfaces instantly as `ConnectionRefusedError`, and there is no AAAA record so IPv6 is not involved. Candidates are listen-queue overflow, a DROP-based rate limit, or conntrack exhaustion.

Windows and Linux runners draw from different egress pools, so "Linux passes with this budget" is a strong prior rather than a proof for Windows. The honest expectation is that this removes the platform asymmetry; whether any residual failures remain depends on `proxy4`, not on the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)