### PR TITLE
feat(config): enable cdpp3dview (3DView) provider by default

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,9 @@ Behavior changes (from https://github.com/SciQLop/speasy/pull/341):
   their offset dropped. Naive inputs are still assumed to be UTC.
 * Dates outside the ``datetime64[ns]`` range (roughly before 1678 or after 2262) now raise
   ``ValueError`` instead of silently wrapping around to a wrong date.
+* The ``cdpp3dview`` (3DView) provider is now enabled by default. It previously shipped disabled
+  while its web service had known issues; those are now mostly resolved. Disable it again via
+  ``disabled_providers`` if you hit problems, see :ref:`disabling_providers`.
 
 * Ensures SSCWeb variables have a name by @jeandet in https://github.com/SciQLop/speasy/pull/266
 * Fix CI break by @jeandet in https://github.com/SciQLop/speasy/pull/269

--- a/docs/user/cdpp3dview/cdpp3dview.rst
+++ b/docs/user/cdpp3dview/cdpp3dview.rst
@@ -10,8 +10,9 @@ planet, spacecraft, and comet trajectories, each available in a choice of coordi
 integration into Speasy makes it easy to get trajectory data for various missions on any time range.
 
 .. note::
-    This provider ships **disabled by default** (its web service has known issues that are still being
-    addressed). Re-enable it by removing ``cdpp3dview`` from ``disabled_providers``, see :ref:`disabling_providers`.
+    This provider is **enabled by default** as of speasy 1.8. It previously shipped disabled while its web
+    service had known issues; those are now mostly resolved, and broader use helps surface what's left. If
+    you hit problems, you can disable it again via ``disabled_providers``, see :ref:`disabling_providers`.
 
 Basics: Getting data from Cdpp3dView module
 --------------------------------------------

--- a/docs/user/configuration.rst
+++ b/docs/user/configuration.rst
@@ -33,9 +33,8 @@ Valid names are ``amda``, ``csa``, ``cda`` (alias ``cdaweb``), ``ssc`` (alias ``
 ``archive`` (alias ``generic_archive``), ``uiowaephtool`` (alias ``UiowaEphTool``) and
 ``cdpp3dview`` (alias ``3DView``).
 
-The value you set **replaces** the default rather than adding to it. The default is ``cdpp3dview``
-(see :doc:`cdpp3dview/cdpp3dview` for why), so setting ``disabled_providers = amda`` also re-enables
-``cdpp3dview`` — include it explicitly if you want to keep it disabled.
+The value you set **replaces** the default rather than adding to it: the default is empty (every provider
+enabled), so setting ``disabled_providers = amda`` disables only AMDA.
 
 For example, to disable AMDA and CDAWeb, add the following to the configuration file:
 

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -163,10 +163,10 @@ def remove_entry(entry: ConfigEntry):
 # user can easily discover them with speasy.config.<completion>
 # ==========================================================================================
 core = ConfigSection("CORE",
-                     disabled_providers={"default": "cdpp3dview",
+                     disabled_providers={"default": "",
                                          "description": """A comma separated list of providers you want to disable.
 The main benefit of disabling providers is to speedup speasy loading.""",
-                                         "type_ctor": lambda x: set(x.split(','))},
+                                         "type_ctor": _parse_dir_set},
                      http_rewrite_rules={"default": {
                          "https://cdaweb.gsfc.nasa.gov/pub/": "https://sciqlop.lpp.polytechnique.fr/cdaweb-data/pub/"},
                          "description": """A dictionary of rules to rewrite URLs before sending requests.


### PR DESCRIPTION
## Summary
- `cdpp3dview` (3DView) shipped disabled by default because its web service had known reliability issues (see the note in `docs/user/cdpp3dview/cdpp3dview.rst`). Those are now mostly resolved, and wider default usage should help surface whatever's left, so it's being enabled by default.
- Switched `disabled_providers`' `type_ctor` from a raw `lambda x: set(x.split(','))` to the existing `_parse_dir_set` helper (already used for three other comma-separated set config entries). The raw version turns an empty-string default into `{''}` instead of an actual empty set — harmless for the intersection check this feeds, but `_parse_dir_set` already exists specifically to avoid that footgun, so this is more consistent with the rest of the file.
- Updated the `cdpp3dview` provider doc note, the `disabled_providers` explanation in `docs/user/configuration.rst` (which explicitly said "the default is `cdpp3dview`"), and added a `HISTORY.rst` behavior-change entry under 1.8.0.

## Test plan
- [x] `tests/test_config_module.py` (15/15) and `tests/test_speasy.py::SpeasyModule::test_can_list_providers` pass with the new default.
- [x] `tests/test_cdpp3dview.py` (33/33) passes against the live service — hit one flaky burst of `AttributeError`s on a first run against the real 3DView server, clean on two reruns; consistent with the documented "known issues," not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)