### PR TITLE
fix(providers): retry providers that failed to initialize, on update_inventories()

### DIFF
--- a/speasy/__init__.py
+++ b/speasy/__init__.py
@@ -34,5 +34,10 @@ def find_product(name: str) -> List[str]:
 
 def update_inventories():
     from .core.dataprovider import PROVIDERS
+    from .core.requests_scheduling.request_dispatch import init_providers
+    # Retries any provider whose one-shot init at import time failed (e.g. a
+    # transient error reaching its web service); a no-op for providers already
+    # initialized, see _safe_init_provider.
+    init_providers()
     for provider in PROVIDERS.values():
         provider.update_inventory()

--- a/speasy/__init__.py
+++ b/speasy/__init__.py
@@ -6,7 +6,10 @@
 
 """
 
+import logging
 from importlib import metadata as _metadata
+
+log = logging.getLogger(__name__)
 
 __author__ = """Alexis Jeandet"""
 __email__ = 'alexis.jeandet@member.fsf.org'
@@ -40,4 +43,8 @@ def update_inventories():
     # initialized, see _safe_init_provider.
     init_providers()
     for provider in PROVIDERS.values():
-        provider.update_inventory()
+        try:
+            provider.update_inventory()
+        except Exception:
+            # One provider's outage must not prevent the others from refreshing.
+            log.warning(f"Failed to refresh inventory for provider {provider.provider_name}", exc_info=True)

--- a/speasy/core/requests_scheduling/request_dispatch.py
+++ b/speasy/core/requests_scheduling/request_dispatch.py
@@ -58,6 +58,11 @@ def _is_server_up(ws_class):
 def _safe_init_provider(ws_class, names, ignore_disabled_status=False):
     """Initialize a data provider safely, catching exceptions and disabling the provider if initialization fails.
 
+    A no-op if the provider is already initialized, which makes it safe to call again
+    later (e.g. from update_inventories()) to retry a provider whose one-shot init at
+    import time failed, without re-constructing (and re-fetching the inventory of)
+    providers that are already up.
+
     Parameters
     ----------
     ws_class : class
@@ -76,9 +81,11 @@ def _safe_init_provider(ws_class, names, ignore_disabled_status=False):
     RuntimeError
         If the server is not running.
     """
+    main_name = names[0]
+    if globals().get(main_name) is not None:
+        return
     try:
         if ignore_disabled_status or not core_cfg.disabled_providers().intersection(set(names)):
-            main_name = names[0]
             if _is_server_up(ws_class):
                 globals()[main_name] = ws_class()
                 for name in names:

--- a/tests/test_provider_init_retry.py
+++ b/tests/test_provider_init_retry.py
@@ -49,5 +49,21 @@ class UpdateInventoriesRetriesFailedProvidersTest(unittest.TestCase):
         mock_init_providers.assert_called_once_with()
 
 
+class UpdateInventoriesIsolatesProviderFailuresTest(unittest.TestCase):
+    def test_one_providers_failure_does_not_block_the_others_or_raise(self):
+        import speasy
+        failing = Mock()
+        failing.provider_name = 'failing'
+        failing.update_inventory.side_effect = RuntimeError("boom")
+        healthy = Mock()
+        healthy.provider_name = 'healthy'
+        fake_providers = {'failing': failing, 'healthy': healthy}
+        with patch.object(rd, 'init_providers'), \
+             patch('speasy.core.dataprovider.PROVIDERS', fake_providers):
+            speasy.update_inventories()  # must not raise
+        failing.update_inventory.assert_called_once_with()
+        healthy.update_inventory.assert_called_once_with()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_provider_init_retry.py
+++ b/tests/test_provider_init_retry.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for the failed-provider-init retry added to update_inventories()."""
+import unittest
+from unittest.mock import Mock, patch
+
+from speasy.core.requests_scheduling import request_dispatch as rd
+
+
+class SafeInitProviderRetryTest(unittest.TestCase):
+    def setUp(self):
+        self._saved_amda = rd.amda
+        self._saved_providers_entries = {name: rd.PROVIDERS[name] for name in ('amda',) if name in rd.PROVIDERS}
+
+    def tearDown(self):
+        rd.amda = self._saved_amda
+        for name, value in self._saved_providers_entries.items():
+            rd.PROVIDERS[name] = value
+
+    def test_does_not_reconstruct_an_already_initialized_provider(self):
+        rd.amda = Mock()
+        with patch.object(rd, 'AmdaWebservice') as mock_cls:
+            rd.init_amda()
+        mock_cls.assert_not_called()
+
+    def test_retries_a_provider_that_previously_failed_to_initialize(self):
+        rd.amda = None
+        fake_instance = Mock()
+        with patch.object(rd, 'AmdaWebservice', return_value=fake_instance), \
+             patch.object(rd, '_is_server_up', return_value=True):
+            rd.init_amda()
+        self.assertIs(rd.amda, fake_instance)
+        self.assertIs(rd.PROVIDERS['amda'], fake_instance)
+
+
+class UpdateInventoriesRetriesFailedProvidersTest(unittest.TestCase):
+    def test_update_inventories_calls_init_providers_before_refreshing(self):
+        # update_inventories() only ever refreshed providers already in PROVIDERS
+        # (speasy.core.dataprovider.PROVIDERS), so a provider whose one-shot init at
+        # import time failed (e.g. a transient error reaching its web service) was
+        # never retried, ever, until the process restarted. init_providers() is a
+        # no-op for every already-initialized provider (see _safe_init_provider), so
+        # calling it again here is safe and just retries whatever is still missing.
+        import speasy
+        with patch.object(rd, 'init_providers') as mock_init_providers, \
+             patch('speasy.core.dataprovider.PROVIDERS', {}):
+            speasy.update_inventories()
+        mock_init_providers.assert_called_once_with()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Each provider's init runs once, at import time (`init_providers()`). If constructing a provider throws for any reason (e.g. a transient error reaching its web service), `_safe_init_provider` catches it, logs a warning, and the provider is simply absent from `PROVIDERS` forever. `update_inventories()` (called both by the import-time bootstrap and by consumers like speasy_proxy's periodic refresh loop) only ever calls `.update_inventory()` on providers already in `PROVIDERS`, so a provider whose one-shot init failed was never retried — no recovery short of restarting the process.
- Observed in practice: after rebuilding speasy_proxy against a commit that enables `cdpp3dview` by default (#349), the running instance still didn't have it. A transient failure reaching 3DView's web service during the single `--preload` import silently and permanently dropped it for that container's life.
- `_safe_init_provider` is now a no-op if the provider is already initialized (a cheap `globals()` check), which makes it safe to call again later without re-constructing (and re-fetching the inventory of) providers that are already up. `update_inventories()` now calls `init_providers()` first, so anything still missing gets retried on the next refresh cycle instead of requiring a restart.
- **Also**: `update_inventories()`'s refresh loop had no per-provider isolation — one provider raising during `.update_inventory()` (e.g. an outage) aborted the whole call, skipping refresh for every provider later in iteration order, not just the failing one. speasy_proxy already wraps the whole call and falls back to last-good inventory on any exception, so in practice a single flaky provider could repeatedly stall fresh data for every other, healthy provider too, cycle after cycle. Each provider's refresh is now caught and logged individually so one provider's outage no longer blocks the others.
- Known residual gap left out of scope: the top-level `speasy.<provider>` attributes (e.g. `spz.cdpp3dview`) are bound once at package-import time via `from .core.requests_scheduling.request_dispatch import ... cdpp3dview`, so they stay stale if a provider recovers later via this retry — everything that actually serves data (`get_data()`, `list_providers()`, the inventory tree) goes through the mutated `PROVIDERS` dict and is correctly picked up, but direct interactive use of e.g. `spz.cdpp3dview.get_frames()` would still need a process restart to see a late recovery. Flagging it rather than expanding this PR's scope to fix it.

## Test plan
- [x] `tests/test_provider_init_retry.py`: idempotency (`_safe_init_provider` doesn't reconstruct an already-initialized provider), retry-when-missing, `update_inventories()` calls `init_providers()`, and one provider's failure doesn't block or raise past the others. Confirmed each new test fails against pre-fix code.
- [x] `tests/test_speasy.py` (32/32, including the real `spz.update_inventories()` integration test against the live proxy) and `tests/test_config_module.py` (15/15) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)