### PR TITLE
fix(codecs): preserve axis metadata when writing ISTP CDF files

### DIFF
--- a/speasy/core/codecs/bundled_codecs/istp/cdf.py
+++ b/speasy/core/codecs/bundled_codecs/istp/cdf.py
@@ -40,6 +40,12 @@ def _convert_attributes_to_variables(variable_name: str, attrs: Mapping, cdf: py
                 values=attr_v
             )
             clean_attrs[name] = target_name
+        elif isinstance(attr_v, list) and len(attr_v) == 1 and isinstance(attr_v[0], str):
+            # the single-entry-list form CDF attributes arrive in (see scalar_meta in
+            # data_containers.py); pycdfpp can only write a string as a scalar attribute, not as a
+            # one-item list of strings, so unwrap it back before handing it off. Numeric single-entry
+            # lists are left alone: pycdfpp needs those to stay list/array-shaped to infer a type.
+            clean_attrs[name] = attr_v[0]
         else:
             clean_attrs[name] = attr_v
     return clean_attrs
@@ -50,15 +56,16 @@ def _write_axis(ax: VariableAxis, cdf: pycdfpp.CDF, compress_variables=False,
     data_type = None
     if ax.values.dtype == np.dtype("datetime64[ns]"):
         data_type = pycdfpp.DataType.CDF_TIME_TT2000
-    # only the record varying marker, not the whole axis meta: that is how the reader tells a
-    # record varying axis from a fixed one, and without it a grid spanning every dimension comes
-    # back time independent and then matches none of them
-    attributes = {"DEPEND_0": time_axis_name} if time_axis_name is not None and ax.is_time_dependent else None
+    attributes = dict(ax.meta or {})
+    if time_axis_name is not None and ax.is_time_dependent:
+        # this is how the reader tells a record varying axis from a fixed one, and without it a
+        # grid spanning every dimension comes back time independent and then matches none of them
+        attributes["DEPEND_0"] = time_axis_name
     cdf.add_variable(
         name=ax.name,
         values=_simplify_shape(ax.values),
         data_type=data_type,
-        attributes=attributes,
+        attributes=_convert_attributes_to_variables(variable_name=ax.name, attrs=attributes, cdf=cdf) if attributes else None,
         compression=pycdfpp.CompressionType.gzip_compression if compress_variables else pycdfpp.CompressionType.no_compression
     )
     return True

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -95,6 +95,37 @@ class TestCDFWriter(unittest.TestCase):
         self.assertEqual(self.v.values.shape, (24, 3))
 
 
+class TestCDFWriterPreservesAxisAttributes(unittest.TestCase):
+    """`_write_axis` used to call `cdf.add_variable` with no `attributes=` at all, so an axis's
+    own metadata (SCALETYP, UNITS, ...) never made it into the file, even though the primary
+    variable's metadata did."""
+
+    @classmethod
+    def setUpClass(cls):
+        from speasy.core.data_containers import DataContainer, VariableAxis, VariableTimeAxis
+        from speasy.products import SpeasyVariable
+
+        time = np.arange('2018-01-01', '2018-01-01T00:01', np.timedelta64(10, 's'), dtype='datetime64[ns]')
+        energy = VariableAxis(name='energy', values=np.arange(5).astype(np.float64),
+                              meta={"SCALETYP": "log", "UNITS": "eV"})
+        var = SpeasyVariable(
+            axes=[VariableTimeAxis(values=time, meta={"UNITS": "ns"}), energy],
+            values=DataContainer(np.random.random((len(time), 5)), is_time_dependent=True, name='flux',
+                                 meta={"VAR_TYPE": "data"}),
+            columns=["Values"])
+
+        codec = get_codec("application/x-cdf")
+        buffer = codec.save_variables([var])
+        cls.back = codec.load_variable('flux', file=bytes(buffer), disable_cache=True)
+
+    def test_non_time_axis_meta_survives(self):
+        self.assertEqual(self.back.axes[1].meta.get("SCALETYP"), "log")
+        self.assertEqual(self.back.axes[1].meta.get("UNITS"), "eV")
+
+    def test_time_axis_meta_survives(self):
+        self.assertEqual(self.back.axes[0].meta.get("UNITS"), "ns")
+
+
 @ddt
 class TestCDFWriterPtrAttributes(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- `_write_axis` never passed `attributes=` to `cdf.add_variable`, so an axis's own metadata (`SCALETYP`, `UNITS`, ...) was silently dropped on CDF write, even though the primary variable's metadata survived the round trip.
- Fixing that surfaced a second, previously-dormant bug: pycdfpp cannot write a single-entry list containing a string as an attribute value (e.g. `VALIDMIN` on a TT2000 time axis comes in as `['1996-01-01T00:00:00.000000000']`) — it raises `ValueError: Unsupported CDF type CDF_CHAR (51) for buffer attribute`. Fixed by unwrapping only `[str]` single-entry lists to a scalar before handing them to pycdfpp; numeric single-entry lists (e.g. `FILLVAL: [-1e+31]`) are left as-is since pycdfpp needs those list-shaped to infer a type.

## Test plan
- [x] New reproducer tests in `tests/test_codecs.py::TestCDFWriterPreservesAxisAttributes` (fail before the fix, pass after)
- [x] `tests/test_codecs.py`, `tests/test_codec_coordinate_grids.py`, `tests/test_netcdf_codec.py` all pass (50/50)
- [x] flake8 (E9,F63,F7,F82) clean on touched files