### PR TITLE
fix(cache): default to move-mode migration, recover from a corrupted cache/index

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -23,7 +23,7 @@ Behavior changes (from https://github.com/SciQLop/speasy/pull/341):
   (``migrate_by_moving`` is now ``True``) instead of copying them, avoiding a silent doubling of
   disk usage for large caches. Set ``SPEASY_CACHE_MIGRATE_BY_MOVING=false`` to restore the old
   copy-with-rollback-backup behaviour. Separately, if the cache or inventory index database is
-  ever found corrupted on open, it is now moved aside and a fresh one is started automatically
+  ever found corrupted on open, it is now deleted and a fresh one is started automatically
   instead of Speasy crashing on import.
 
 * Ensures SSCWeb variables have a name by @jeandet in https://github.com/SciQLop/speasy/pull/266

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,6 +19,12 @@ Behavior changes (from https://github.com/SciQLop/speasy/pull/341):
 * The ``cdpp3dview`` (3DView) provider is now enabled by default. It previously shipped disabled
   while its web service had known issues; those are now mostly resolved. Disable it again via
   ``disabled_providers`` if you hit problems, see :ref:`disabling_providers`.
+* The one-time diskcache -> sciqlop-cache migration now moves legacy entries by default
+  (``migrate_by_moving`` is now ``True``) instead of copying them, avoiding a silent doubling of
+  disk usage for large caches. Set ``SPEASY_CACHE_MIGRATE_BY_MOVING=false`` to restore the old
+  copy-with-rollback-backup behaviour. Separately, if the cache or inventory index database is
+  ever found corrupted on open, it is now moved aside and a fresh one is started automatically
+  instead of Speasy crashing on import.
 
 * Ensures SSCWeb variables have a name by @jeandet in https://github.com/SciQLop/speasy/pull/266
 * Fix CI break by @jeandet in https://github.com/SciQLop/speasy/pull/269

--- a/speasy/config/__init__.py
+++ b/speasy/config/__init__.py
@@ -211,11 +211,13 @@ cache = ConfigSection("CACHE",
                             "type_ctor": lambda x: int(float(x))},
                       path={"default": str(appdirs.user_cache_dir("speasy", "LPP")),
                             "description": """Sets Speasy cache path."""},
-                      migrate_by_moving={"default": False,
+                      migrate_by_moving={"default": True,
                                         "description": """If true, the one-time diskcache -> sciqlop-cache
 migration deletes each legacy entry as soon as it's copied, instead of preserving the whole legacy cache
 as a rollback backup. Uses much less peak disk space during migration, at the cost of not being able to
-fall back to the legacy cache if the new one turns out to have an issue. Off by default.""",
+fall back to the legacy cache if the new one turns out to have an issue. On by default, since this is
+just a cache (data is always re-fetchable) and most users would rather not silently double their disk
+usage during migration; set to false to keep the old copy-with-rollback-backup behaviour.""",
                                         "type_ctor": lambda x: {'true': True, 'false': False}.get(x.lower(), False)},
                       )
 

--- a/speasy/core/cache/cache.py
+++ b/speasy/core/cache/cache.py
@@ -246,13 +246,15 @@ def _open_or_recover(ctor, full_path: str, label: str):
     """Call ``ctor()`` to open the cache/index database at ``full_path``. If it
     raises -- the database is corrupted, which can happen after a move-mode
     migration interrupted mid-way (see ``migrate_by_moving``) or from
-    unrelated disk corruption -- move the broken directory aside and retry
-    once with a fresh one.
+    unrelated disk corruption -- delete the broken directory and retry once
+    with a fresh one.
 
     Both :class:`Cache` and ``SpeasyIndex`` are constructed at Speasy import
     time, so letting this exception propagate would crash every ``import
     speasy`` until the user manually found and deleted the offending
-    directory. Degrading to "start over" is preferable: it's just a cache.
+    directory. Degrading to "start over" is preferable: it's just a cache,
+    and a corrupted database has no rollback value worth keeping around --
+    unlike a legacy migration backup, there's nothing recoverable in it.
     """
     try:
         return ctor()
@@ -260,13 +262,11 @@ def _open_or_recover(ctor, full_path: str, label: str):
         p = Path(full_path)
         if not p.exists():
             raise
-        broken = Path(f"{full_path}.corrupted-{datetime.now(tz=timezone.utc):%Y%m%dT%H%M%S%f}")
         log.exception(
-            f"Could not open the {label} at {full_path} (likely corrupted); moving it aside to "
-            f"{broken} and starting fresh so Speasy can still start. Delete {broken} once you've "
-            f"confirmed you don't need anything from it."
+            f"Could not open the {label} at {full_path} (likely corrupted); deleting it and "
+            f"starting fresh so Speasy can still start."
         )
-        os.rename(str(p), str(broken))
+        shutil.rmtree(str(p))
         return ctor()
 
 

--- a/speasy/core/cache/cache.py
+++ b/speasy/core/cache/cache.py
@@ -242,6 +242,34 @@ def _migrate_legacy_diskcache(full_path: str, move: bool = False) -> bool:
     return True
 
 
+def _open_or_recover(ctor, full_path: str, label: str):
+    """Call ``ctor()`` to open the cache/index database at ``full_path``. If it
+    raises -- the database is corrupted, which can happen after a move-mode
+    migration interrupted mid-way (see ``migrate_by_moving``) or from
+    unrelated disk corruption -- move the broken directory aside and retry
+    once with a fresh one.
+
+    Both :class:`Cache` and ``SpeasyIndex`` are constructed at Speasy import
+    time, so letting this exception propagate would crash every ``import
+    speasy`` until the user manually found and deleted the offending
+    directory. Degrading to "start over" is preferable: it's just a cache.
+    """
+    try:
+        return ctor()
+    except Exception:
+        p = Path(full_path)
+        if not p.exists():
+            raise
+        broken = Path(f"{full_path}.corrupted-{datetime.now(tz=timezone.utc):%Y%m%dT%H%M%S%f}")
+        log.exception(
+            f"Could not open the {label} at {full_path} (likely corrupted); moving it aside to "
+            f"{broken} and starting fresh so Speasy can still start. Delete {broken} once you've "
+            f"confirmed you don't need anything from it."
+        )
+        os.rename(str(p), str(broken))
+        return ctor()
+
+
 def _warn_if_backup_present(full_path: str) -> None:
     """Log a reminder if a migration backup still sits next to ``full_path``.
 
@@ -308,11 +336,13 @@ class Cache:
         _warn_if_backup_present(full_path)
 
         if cache_type == "Fanout":
-            self._data = sc.FanoutCache(
-                cache_path=full_path, shard_count=8, max_size=cache_cfg.size()
-            )
+            self._data = _open_or_recover(
+                lambda: sc.FanoutCache(cache_path=full_path, shard_count=8, max_size=cache_cfg.size()),
+                full_path, "cache")
         elif cache_type == "Cache":
-            self._data = sc.Cache(cache_path=full_path, max_size=cache_cfg.size())
+            self._data = _open_or_recover(
+                lambda: sc.Cache(cache_path=full_path, max_size=cache_cfg.size()),
+                full_path, "cache")
         else:
             raise ValueError(f"Unimplemented cache type: {cache_type}")
 

--- a/speasy/core/index/speasy_index.py
+++ b/speasy/core/index/speasy_index.py
@@ -4,16 +4,17 @@ except ImportError:  # pragma: no cover - platform-specific (WASM has no wheel)
     # No compiled backend (e.g. WASM/Pyodide): fall back to a no-op store.
     from speasy.core.cache import _noop_cache as sc
 
+from speasy.config import cache as cache_cfg
 from speasy.config import index as index_cfg
-from speasy.core.cache.cache import _migrate_legacy_diskcache, _warn_if_backup_present
+from speasy.core.cache.cache import _migrate_legacy_diskcache, _warn_if_backup_present, _open_or_recover
 
 
 class SpeasyIndex:
     def __init__(self):
         path = index_cfg.path()
-        _migrate_legacy_diskcache(path)
+        _migrate_legacy_diskcache(path, move=cache_cfg.migrate_by_moving())
         _warn_if_backup_present(path)
-        self._index = sc.Index(path=path)
+        self._index = _open_or_recover(lambda: sc.Index(path=path), path, "index")
 
     def get(self, module, key, default=None):
         return self._index.get(f'{module}/{key}', default)

--- a/tests/test_cache_migration.py
+++ b/tests/test_cache_migration.py
@@ -21,6 +21,7 @@ from speasy.core.cache.cache import (
     migration_backups,
     delete_migration_backups,
 )
+from speasy.core.index.speasy_index import SpeasyIndex
 
 
 class LegacyDiskcacheMigration(unittest.TestCase):
@@ -93,6 +94,44 @@ class LegacyDiskcacheMigration(unittest.TestCase):
         remaining = diskcache.Cache(backup)
         self.assertEqual(list(remaining), [],
                          "legacy entries should be deleted once migrated in move mode")
+
+    def test_corrupted_cache_db_is_moved_aside_and_speasy_still_starts(self):
+        """A corrupted sciqlop-cache.db (e.g. left behind by a move-mode migration
+        interrupted mid-way, or unrelated disk corruption) makes the native backend
+        raise on open. Since Cache() is constructed at Speasy import time
+        (speasy/core/cache/_instance.py), letting that exception propagate would
+        crash every ``import speasy`` until the user manually deleted the offending
+        directory. Speasy must instead move the broken directory aside and start
+        fresh."""
+        full_path = f"{self.root}/Cache"
+        os.makedirs(full_path, exist_ok=True)
+        with open(os.path.join(full_path, "sciqlop-cache.db"), "wb") as f:
+            f.write(b"not a real sqlite database")
+
+        cache = Cache(self.root)  # must not raise
+        cache.set("k", "v")
+        self.assertEqual(cache.get("k"), "v")
+
+        broken = [p for p in os.listdir(self.root) if p.startswith("Cache.corrupted-")]
+        self.assertEqual(len(broken), 1, "the corrupted directory should be moved aside, not left in place")
+
+    def test_corrupted_index_db_is_moved_aside_and_speasy_still_starts(self):
+        """Same corruption-recovery guarantee for the inventory disk-index
+        (SpeasyIndex), which is also constructed at Speasy import time
+        (speasy/core/index/__init__.py)."""
+        os.makedirs(self.root, exist_ok=True)
+        with open(os.path.join(self.root, "sciqlop-cache.db"), "wb") as f:
+            f.write(b"not a real sqlite database")
+
+        with mock.patch.dict(os.environ, {"SPEASY_INDEX_PATH": self.root}):
+            index = SpeasyIndex()  # must not raise
+            index.set("mod", "key", "value")
+            self.assertEqual(index.get("mod", "key"), "value")
+
+        broken = [p for p in os.listdir(os.path.dirname(self.root))
+                  if p.startswith(f"{os.path.basename(self.root)}.corrupted-")]
+        self.assertEqual(len(broken), 1, "the corrupted directory should be moved aside, not left in place")
+        shutil.rmtree(os.path.join(os.path.dirname(self.root), broken[0]), ignore_errors=True)
 
     def test_falls_back_gracefully_when_diskcache_unavailable(self):
         """diskcache is a required runtime dependency, but ``migrate()`` imports it lazily

--- a/tests/test_cache_migration.py
+++ b/tests/test_cache_migration.py
@@ -95,14 +95,14 @@ class LegacyDiskcacheMigration(unittest.TestCase):
         self.assertEqual(list(remaining), [],
                          "legacy entries should be deleted once migrated in move mode")
 
-    def test_corrupted_cache_db_is_moved_aside_and_speasy_still_starts(self):
+    def test_corrupted_cache_db_is_deleted_and_speasy_still_starts(self):
         """A corrupted sciqlop-cache.db (e.g. left behind by a move-mode migration
         interrupted mid-way, or unrelated disk corruption) makes the native backend
         raise on open. Since Cache() is constructed at Speasy import time
         (speasy/core/cache/_instance.py), letting that exception propagate would
         crash every ``import speasy`` until the user manually deleted the offending
-        directory. Speasy must instead move the broken directory aside and start
-        fresh."""
+        directory. Speasy must instead delete the broken directory (it has no
+        rollback value -- it's corrupted) and start fresh."""
         full_path = f"{self.root}/Cache"
         os.makedirs(full_path, exist_ok=True)
         with open(os.path.join(full_path, "sciqlop-cache.db"), "wb") as f:
@@ -112,10 +112,10 @@ class LegacyDiskcacheMigration(unittest.TestCase):
         cache.set("k", "v")
         self.assertEqual(cache.get("k"), "v")
 
-        broken = [p for p in os.listdir(self.root) if p.startswith("Cache.corrupted-")]
-        self.assertEqual(len(broken), 1, "the corrupted directory should be moved aside, not left in place")
+        leftovers = [p for p in os.listdir(self.root) if p != "Cache"]
+        self.assertEqual(leftovers, [], "the corrupted directory should be deleted, not left around")
 
-    def test_corrupted_index_db_is_moved_aside_and_speasy_still_starts(self):
+    def test_corrupted_index_db_is_deleted_and_speasy_still_starts(self):
         """Same corruption-recovery guarantee for the inventory disk-index
         (SpeasyIndex), which is also constructed at Speasy import time
         (speasy/core/index/__init__.py)."""
@@ -128,10 +128,9 @@ class LegacyDiskcacheMigration(unittest.TestCase):
             index.set("mod", "key", "value")
             self.assertEqual(index.get("mod", "key"), "value")
 
-        broken = [p for p in os.listdir(os.path.dirname(self.root))
-                  if p.startswith(f"{os.path.basename(self.root)}.corrupted-")]
-        self.assertEqual(len(broken), 1, "the corrupted directory should be moved aside, not left in place")
-        shutil.rmtree(os.path.join(os.path.dirname(self.root), broken[0]), ignore_errors=True)
+        leftovers = [p for p in os.listdir(os.path.dirname(self.root))
+                     if p.startswith(f"{os.path.basename(self.root)}.")]
+        self.assertEqual(leftovers, [], "no corrupted-directory leftovers should remain")
 
     def test_falls_back_gracefully_when_diskcache_unavailable(self):
         """diskcache is a required runtime dependency, but ``migrate()`` imports it lazily


### PR DESCRIPTION
## Summary
- `migrate_by_moving` now defaults to `True`: the one-time diskcache -> sciqlop-cache migration moves legacy entries instead of copying them. Most users won't know why their disk usage silently doubled during migration, and it's just a re-fetchable cache, so the rollback-safety tradeoff isn't worth it as the default. `SpeasyIndex` previously ignored this config entirely (always copied); it now honors it too.
- `Cache` and `SpeasyIndex` are both constructed at Speasy import time. If the on-disk database turns out corrupted (e.g. a move-mode migration killed mid-way, or unrelated disk corruption), opening it used to raise straight out of `import speasy`. It's now caught, the corrupted directory is deleted (it has no rollback value), and a fresh cache/index is started so Speasy still starts.

## Test plan
- [x] `tests/test_cache_migration.py` (12 tests, including two new reproducers: corrupted cache DB and corrupted index DB, each confirmed to crash before the fix)
- [x] `tests/test_cache.py` + `tests/test_cache_migration.py` full run: 303 passed
- [x] flake8 (E9,F63,F7,F82) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)