### PR TITLE
fix(cache): stop trusting immortal cache entries written by older speasy

### DIFF
--- a/speasy/core/cache/_providers_caches.py
+++ b/speasy/core/cache/_providers_caches.py
@@ -38,7 +38,12 @@ def round_for_cache(dt_range: DateTimeRange, fragment_hours: int):
 
 
 def is_up_to_date(item: CacheItem, version):
-    return (item.version is None) or (item.version >= version)
+    try:
+        return (item.version is None) or (item.version >= version)
+    except TypeError:
+        # Cache entries live for years and older Speasy versions stored other
+        # version types (e.g. datetime before v1.7.0); incomparable means outdated.
+        return False
 
 
 def group_fragments_if(fragments, predicate):
@@ -376,6 +381,12 @@ class UnversionedProviderCache(object):
         maybe_outdated_fragments = []
         for fragment, entry in zip(fragments, entries):
             if entry is None:
+                missing_fragments.append(fragment)
+            elif entry.version != self.version:
+                # An entry written under another version scheme (e.g. the pre-v1.7.0
+                # datetime.now() versions) may hold a payload whose shape or coverage no
+                # longer matches what the service serves today, and the if_newer_than/304
+                # refresh below would keep it alive forever. Force a real refetch.
                 missing_fragments.append(fragment)
             elif (not entry.is_expired() and entry.lifetime is not None) or prefer_cache:
                 try:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -139,6 +139,53 @@ class _CacheTest(unittest.TestCase):
             var = self._make_data("test_get_newer_version_data", tstart, tend)
             self.assertEqual(self._make_data_cntr, i + 1)
 
+    @data(
+        (datetime(2021, 5, 31, tzinfo=timezone.utc), '2026-08-30T04:36:29Z'),
+        ('2021-05-31T00:00:00Z', datetime(2026, 8, 30, 4, 36, 29, tzinfo=timezone.utc)),
+    )
+    @unpack
+    def test_version_type_change_invalidates_cache_instead_of_crashing(self, cached_version, new_version):
+        # Entries written by old Speasy versions can carry a datetime version while
+        # the current code produces str (or vice versa); the comparison must mean
+        # "outdated", not raise TypeError.
+        product = f"test_version_type_change_{type(cached_version).__name__}_to_{type(new_version).__name__}"
+        tstart = datetime(2012, 2, 1, 8, 0, tzinfo=timezone.utc)
+        tend = tstart + timedelta(minutes=30)
+        self._version = cached_version
+        self._make_data(product, tstart, tend)
+        self.assertEqual(self._make_data_cntr, 1)
+        self._version = new_version
+        var = self._make_data(product, tstart, tend)
+        self.assertIsNotNone(var)
+        self.assertEqual(self._make_data_cntr, 2)
+
+    def test_unversioned_entries_from_another_era_are_refetched(self):
+        # Until v1.7.0 the unversioned cache wrote entries with version=datetime.now();
+        # the 304/bump_creation_time refresh keeps such entries alive forever with
+        # their original payload. An entry whose version differs from the current
+        # scheme must be refetched for real, not served or 304-refreshed.
+        product = "test_unversioned_fossil_entries"
+        tstart = datetime(2019, 3, 2, 6, 0, tzinfo=timezone.utc)
+        tend = tstart + timedelta(minutes=10)
+        self._make_stable_unversioned_data(product, tstart, tend)
+        self.assertEqual(self._make_unversioned_data_cntr, 1)
+        self._make_stable_unversioned_data(product, tstart, tend)
+        self.assertEqual(self._make_unversioned_data_cntr, 1)
+
+        leaked_cache = self._make_stable_unversioned_data.cache
+        fossil_keys = [key for key in leaked_cache.keys() if product in key]
+        self.assertGreater(len(fossil_keys), 0)
+        for key in fossil_keys:
+            item = leaked_cache[key]
+            item.version = datetime(2025, 12, 1, 4, 59, 59)
+            leaked_cache[key] = item
+
+        var = self._make_stable_unversioned_data(product, tstart, tend)
+        self.assertIsNotNone(var)
+        self.assertEqual(self._make_unversioned_data_cntr, 2)
+        for key in fossil_keys:
+            self.assertEqual(leaked_cache[key].version, "1.0.0")
+
     def test_get_same_version_data(self):
         tstart = datetime(2010, 6, 1, 12, 0, tzinfo=timezone.utc)
         tend = datetime(2010, 6, 1, 15, 30, tzinfo=timezone.utc)


### PR DESCRIPTION
## The problem

Two crash classes showed up on the speasy-proxy production server (55 and 102 occurrences/day), plus zero-row data served to CI. All three had one root cause.

1. Old speasy wrote bad cache entries. Until v1.7.0, the unversioned provider cache stamped every entry with `version=datetime.now()` — a raw datetime object (introduced in ed557dd, removed in 3f677cb).
2. Those entries never die. The 7-day staleness check sends If-Modified-Since; the upstream file (from 2015 or 2021) never changes, so the server answers 304; speasy then keeps the old entry verbatim and only resets its clock. This repeats forever.
3. So whatever was wrong at write time stays wrong forever:
   - a datetime version meets today's str version in `is_up_to_date()` → `TypeError: '>=' not supported between instances of 'datetime.datetime' and 'str'`;
   - a fragment cached when CDAWeb served `mms1_fgm_b_bcs_srvy_l2_clean` with 3 columns meets a fresh 4-column fetch → `could not broadcast input array from shape (691190,4) into shape (691190,3)` in `merge()`;
   - a fragment holding only ~2.5 h of data but claiming a 12 h range serves zero rows for the uncovered part.

A live fossil was dumped from the prod cache during the investigation: two entries with `version=datetime(2025, 12, 1, 4, 59, 59, 132840)` — identical to the microsecond, because the old code evaluated `datetime.now()` once per fragment group — with `created` bumped to the current day by the 304 path.

## The fix

1. `is_up_to_date()`: a version comparison that raises `TypeError` now means "outdated". The entry is refetched and overwritten instead of crashing the request.
2. The unversioned read path now actually checks each entry's stored version against the current scheme (`"1.0.0"`). It was written into every entry but never read back. A mismatch treats the entry as missing: full refetch, no If-Modified-Since. Every pre-v1.7.0 fossil is replaced the first time it is touched, and bumping `self.version` becomes a usable mass-invalidation lever for the future.

## Tests

Both reproducers were written first and failed with the exact production error classes before the fix:
- `test_version_type_change_invalidates_cache_instead_of_crashing` (both type directions, ddt)
- `test_unversioned_entries_from_another_era_are_refetched`

`tests/test_cache.py`: 294 passed. `tests/test_cache_migration.py`: 12 passed. flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)