### PR TITLE
fix(cdpp3dview): fetch frames lazily when the inventory comes from the proxy

### DIFF
--- a/speasy/data_providers/cdpp3dview/__init__.py
+++ b/speasy/data_providers/cdpp3dview/__init__.py
@@ -224,6 +224,13 @@ class Cdpp3dViewWebservice(DataProvider):
             return None
 
     def get_frames(self) -> List[str]:
+        if not self._frames:
+            # build_inventory() is the only other place that fills the frames list,
+            # and it never runs locally when the inventory is served by the proxy.
+            try:
+                self._frames = self._build_frames_list()
+            except Exception as e:
+                log.warning(f"Failed to retrieve coordinate frames from 3dView: {e}")
         return self._frames
 
     def parameter_range(

--- a/tests/test_cdpp3dview.py
+++ b/tests/test_cdpp3dview.py
@@ -290,3 +290,29 @@ class ConditionalRequest(unittest.TestCase):
         self.assertEqual(1, len(trajectory_calls))
         self.assertEqual(trajectory_calls[0].kwargs["headers"]["If-Modified-Since"],
                          "Thu, 01 Jan 2026 00:00:00 GMT")
+
+
+@unittest.skipIf(spz.config.core.disabled_providers.get().intersection({'cdpp3dview', '3DView'}), "cdpp3dview provider not available")
+class Cdpp3dViewFramesWithProxyInventory(unittest.TestCase):
+    # When the inventory is served by the speasy proxy, build_inventory() never
+    # runs locally and self._frames stays empty for the whole session. get_frames
+    # must then fetch the list itself instead of silently returning [].
+
+    def setUp(self):
+        self._saved_frames = spz.cdpp3dview._frames
+        spz.cdpp3dview._frames = []
+
+    def tearDown(self):
+        spz.cdpp3dview._frames = self._saved_frames
+
+    def test_get_frames_builds_lazily_when_inventory_came_from_proxy(self):
+        from unittest.mock import patch
+        with patch.object(spz.cdpp3dview, '_build_frames_list', return_value=['J2000', 'GSE']) as build:
+            self.assertEqual(spz.cdpp3dview.get_frames(), ['J2000', 'GSE'])
+            self.assertEqual(spz.cdpp3dview.get_frames(), ['J2000', 'GSE'])
+        self.assertEqual(build.call_count, 1)
+
+    def test_get_frames_stays_empty_when_service_unreachable(self):
+        from unittest.mock import patch
+        with patch.object(spz.cdpp3dview, '_build_frames_list', side_effect=IOError("service down")):
+            self.assertEqual(spz.cdpp3dview.get_frames(), [])


### PR DESCRIPTION
## The problem

Three `test_cdpp3dview.py` tests fail on CI whenever the speasy proxy is up ("No available coordinate frames retrieved from 3dView"). This looked like a 3DView outage, but the service is healthy — the failure is deterministic and local to speasy:

1. The frames list is only built inside `build_inventory()`.
2. `_inventory` is `@Proxyfiable`. When the proxy serves the cdpp3dview inventory, `build_inventory()` never runs locally.
3. So `get_frames()` returns `[]` for the whole session: frame validation silently falls back to J2000 instead of raising `Cdpp3dViewWebException`, and `test_get_frames` gets an empty list.

It started now because the prod proxy was rebuilt against a speasy that ships the cdpp3dview provider, so it began serving that inventory (verified: `get_inventory?provider=cdpp3dview` returns 200 with a 61 KB tree).

## The fix

`get_frames()` builds the list on first use when it is empty. The warn-and-fallback behavior for an unreachable service is kept.

## Tests

Two new unit tests simulate the proxy-inventory state (`_frames = []`) with a mocked `_build_frames_list`: lazy build happens once and is cached; an unreachable service still yields `[]` without raising. The lazy-build test failed before the fix. Full `tests/test_cdpp3dview.py`: 35 passed locally through the live proxy-inventory path — including the three tests that were red on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)