### PR TITLE
fix(impex): don't crash when AMDA/CSA server is unreachable

### DIFF
--- a/speasy/core/impex/client.py
+++ b/speasy/core/impex/client.py
@@ -151,6 +151,8 @@ class ImpexClient:
     def _send_indirect_request(self, endpoint: ImpexEndpoint, params: dict = None,
                                timeout: int = http.DEFAULT_TIMEOUT) -> str or None:
         next_url = self._send_request(endpoint=endpoint, params=params, timeout=timeout)
+        if next_url is None:
+            return None
         if '<' in next_url and '>' in next_url:
             next_url = next_url.split(">")[1].split("<")[0]
         r = http.get(next_url, timeout=timeout)

--- a/tests/test_impex_client.py
+++ b/tests/test_impex_client.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for `speasy.core.impex.client`."""
+import unittest
+from unittest.mock import patch
+
+from speasy.core.impex.client import ImpexClient, ImpexEndpoint
+
+
+class ImpexClientTest(unittest.TestCase):
+    def setUp(self):
+        self.client = ImpexClient(server_url="http://impex.example.org",
+                                  capabilities=[ImpexEndpoint.OBSTREE])
+
+    def test_send_indirect_request_returns_none_when_server_unreachable(self):
+        # https://github.com/SciQLop/speasy/issues/228
+        # When the server is unreachable, _send_request already returns None.
+        # _send_indirect_request must not crash trying to parse that as a URL.
+        with patch.object(self.client, '_send_request', return_value=None):
+            result = self.client._send_indirect_request(ImpexEndpoint.OBSTREE)
+        self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- `_send_indirect_request` ran string parsing (`'<' in next_url`) on the result of `_send_request` without checking for `None`, which it returns whenever the server responds with anything other than a 200 (e.g. AMDA returning 502s while down). That turned a server outage into `TypeError: argument of type 'NoneType' is not iterable` instead of a clean `None`.
- Added a `None` guard so an unreachable/misbehaving server now degrades to `None` like every other caller of `_send_request` already expects.

Fixes #228

## Test plan
- [x] Added `tests/test_impex_client.py::test_send_indirect_request_returns_none_when_server_unreachable`, confirmed it reproduces the exact `TypeError` from the issue before the fix, and passes after
- [x] `flake8` (E9,F63,F7,F82) clean on changed files